### PR TITLE
patch: 1.0.0 - manual-students-update

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -18,6 +18,7 @@ jobs:
       audit_severity: "high" # required to be set. Can be one of (null, info, low, moderate, high, critical, none)
 
   build-and-deploy:
+    needs: call-security
     runs-on: self-hosted
     steps:
       - name: 'Checkout GitHub Action'

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -16,7 +16,6 @@ jobs:
     uses: vestfoldfylke/shared/.github/workflows/npm-security.yml@main
     with:
       audit_severity: "high" # required to be set. Can be one of (null, info, low, moderate, high, critical, none)
-      node_version: 22 # this one is optional and defaults to 22 if not set
 
   build-and-deploy:
     runs-on: self-hosted

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -368,7 +368,7 @@
         {/if}
   
         <div class="manual-students">
-          {#if manualStudents.length }
+          {#if manualStudents.length > 0 }
             <table class="ds-table">
               <thead>
                 <tr>

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -189,6 +189,11 @@
         "Content-Type": "application/json"
       }
     })
+
+    // reset new manual student form
+    closeNewManualStudentForm()
+    newManualStudentFnr = ""
+    newManualStudentName = ""
   }
 
   let canManageManualStudents = $derived.by(() => {

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -368,30 +368,34 @@
         {/if}
   
         <div class="manual-students">
-          <table class="ds-table">
-            <thead>
-              <tr>
-                <th aria-sort="ascending">
-                  <button type="button">Navn</button>
-                </th>
-                <th>
-                  Rediger
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-            {#each manualStudents as manualStudent}
-              <tr>
-                <td>
-                  <a href={`/students/${manualStudent._id}`} class="ds-link" rel="noopener noreferrer">{manualStudent.name}</a>
-                </td>
-                <td>
-                  <a href={`${page.url.pathname}/manualstudents/${manualStudent._id}`} class="ds-link" rel="noopener noreferrer">Rediger</a>
-                </td>
-              </tr>
-            {/each}
-            </tbody>
-          </table>
+          {#if manualStudents.length }
+            <table class="ds-table">
+              <thead>
+                <tr>
+                  <th aria-sort="ascending">
+                    <button type="button">Navn</button>
+                  </th>
+                  <th>
+                    Rediger
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+              {#each manualStudents as manualStudent}
+                <tr>
+                  <td>
+                    <a href={`/students/${manualStudent._id}`} class="ds-link" rel="noopener noreferrer">{manualStudent.name}</a>
+                  </td>
+                  <td>
+                    <a href={`${page.url.pathname}/manualstudents/${manualStudent._id}`} class="ds-link" rel="noopener noreferrer">Rediger</a>
+                  </td>
+                </tr>
+              {/each}
+              </tbody>
+            </table>
+          {:else}
+            <span>Ingen manuelle elever her</span>
+          {/if}
         </div>
       </ds-tabpanel>
     {/if}

--- a/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
@@ -74,7 +74,7 @@
   {#if !updateManualStudentEdit}
     <div class="update-manual-student">
       <div>
-        <h6 class="ds-heading">Fødselsnummer</h6>
+        <h2 class="ds-heading">Fødselsnummer</h2>
         <p class="ds-paragraph">{updateManualStudentFnr}</p>
       </div>
       <div class="manual-student-edit-action">

--- a/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
@@ -25,7 +25,7 @@
     return school
   })
 
-  // new manual student
+  let updateManualStudentEdit: boolean = $state(false)
   let updateManualStudentForm: HTMLFormElement | undefined = $state()
   let updateManualStudentFnr: string = $derived.by(() => data.manualStudent.ssn)
   let updateManualStudentName: string = $derived.by(() => data.manualStudent.name)
@@ -57,25 +57,34 @@
         "Content-Type": "application/json"
       }
     })
+
+    updateManualStudentEdit = false
   }
 
-  let canManageManualStudents = $derived.by(() => {
-    if (!data.principalAccess) {
-      return false
-    }
-
-    return canManageManualStudentsOnSchool(data.principalAccess, currentSchool.schoolNumber)
-  })
-
   const abortUpdateManualStudent = () => {
-    console.log("Meh")
+    updateManualStudentEdit = false
+    updateManualStudentFnr = data.manualStudent.ssn
+    updateManualStudentName = data.manualStudent.name
   }
 </script>
 
 <div class="page-content">
-  <PageHeader title={data.manualStudent.name} />
-  
-  {#if canManageManualStudents}
+  <PageHeader title={`Manuell elev - ${data.manualStudent.name}`} />
+
+  {#if !updateManualStudentEdit}
+    <div class="update-manual-student">
+      <div>
+        <h6 class="ds-heading">Fødselsnummer</h6>
+        <p class="ds-paragraph">{updateManualStudentFnr}</p>
+      </div>
+      <div class="manual-student-edit-action">
+        <button onclick={() => updateManualStudentEdit = true} class="ds-button">
+          <span class="material-symbols-outlined">edit</span>
+          Rediger
+        </button>
+      </div>
+    </div>
+  {:else}
     <div class="update-manual-student-form">
       <form bind:this={updateManualStudentForm}>
         <ds-field class="ds-field content-item">
@@ -99,16 +108,20 @@
         </ds-field>
       </form>
 
-      <div class="manual-student-actions">
-        <AsyncButton onClick={updateManualStudent} buttonText="Oppdater manuell elev" iconName="update" reloadPageDataOnSuccess={true} />
+      <div class="manual-student-save-actions">
+        <AsyncButton onClick={updateManualStudent} buttonText="Lagre" iconName="save" reloadPageDataOnSuccess={true} disabled={updateManualStudentFnr === data.manualStudent.ssn && updateManualStudentName === data.manualStudent.name} />
         <button class="ds-button" type="button" data-variant="secondary" onclick={abortUpdateManualStudent}><span class="material-symbols-outlined">close</span>Avbryt</button>
       </div>
     </div>
   {/if}
 </div>
 
-<style>  
-  .manual-student-actions {
+<style>
+  .manual-student-edit-action {
+      padding-top: var(--ds-size-4);
+  }
+
+  .manual-student-save-actions {
       display: flex;
       gap: 0.5rem;
       justify-content: flex-end;


### PR DESCRIPTION
### Patch commits:
- fix: reset new manual student form when manual student has been added (c3b13df)
- fix: Make sure that manualStudents length is greater than 0 (c2d47ad)

### Maintenance commits:
- chore: Updated updated manual student view (516da8b)
- chore: Make `build-and-deploy` dependent on `call-security` to have been run successfully (92fe9f3)
- chore: Don't specify `node_version` unless other than default node_version is to be used (4f95dc3)
- chore: Show a placeholder when no manual students exist on this school (0d52125)
