### PR TITLE
patch: 1.0.0 - fix-mongodb-ignore-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run check && vite dev",
-    "build": "vite build --mode build",
+    "build": "npm rebuild mongodb-client-encryption && vite build --mode build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
### Patch commits:
- fix: mongodb-client-encryption requires scripts for installing libmongocrypt as a post install (ef50d71)
