### PR TITLE
minor: 1.0.0 - metric-improvements

### DIFF
--- a/src/lib/server/db/mongodb-client.ts
+++ b/src/lib/server/db/mongodb-client.ts
@@ -585,7 +585,7 @@ export class MongoDbClient implements IDbClient {
       name: "ProgramArea_Create",
       description: "Number of program areas created"
     }
-    const labels: [labelName: string, labelValue: string][] = [["schoolNumber", programArea.schoolNumber]]
+    const labels: MetricLabel[] = [["schoolNumber", programArea.schoolNumber]]
 
     if (!result.insertedId) {
       incrementCount({
@@ -615,7 +615,7 @@ export class MongoDbClient implements IDbClient {
       name: "ProgramArea_Update",
       description: "Number of program areas updated"
     }
-    const labels: [labelName: string, labelValue: string][] = [["schoolNumber", programArea.schoolNumber]]
+    const labels: MetricLabel[] = [["schoolNumber", programArea.schoolNumber]]
 
     if (updateResult.matchedCount === 0) {
       incrementCount({
@@ -645,7 +645,7 @@ export class MongoDbClient implements IDbClient {
       name: "ProgramArea_Remove",
       description: "Number of program areas removed"
     }
-    const labels: [labelName: string, labelValue: string][] = [["schoolNumber", programArea.schoolNumber]]
+    const labels: MetricLabel[] = [["schoolNumber", programArea.schoolNumber]]
 
     if (deleteResult.deletedCount === 0) {
       incrementCount({

--- a/src/lib/server/db/mongodb-client.ts
+++ b/src/lib/server/db/mongodb-client.ts
@@ -416,7 +416,8 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "AccessEntry_Create",
-      description: "Number of access entries created"
+      description: "Number of access entries created",
+      splitMetricByLabels: true
     }
     const labels: MetricLabel[] = [
       ["schoolNumber", accessEntry.schoolNumber],
@@ -466,7 +467,8 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "AccessEntry_Remove",
-      description: "Number of access entries removed"
+      description: "Number of access entries removed",
+      splitMetricByLabels: true
     }
     const labels: MetricLabel[] = [
       ["schoolNumber", accessEntry.schoolNumber],
@@ -1127,12 +1129,10 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "StudentDocument_Create",
-      description: "Number of student documents created"
+      description: "Number of student documents created",
+      splitMetricByLabels: true
     }
-    const labels: MetricLabel[] = [
-      ["schoolNumber", document.school.schoolNumber],
-      ["templateName", document.template.name]
-    ]
+    const labels: MetricLabel[] = [["schoolNumber", document.school.schoolNumber]]
 
     if (!result.insertedId) {
       incrementCount({
@@ -1173,12 +1173,10 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "StudentDocument_Update",
-      description: "Number of student documents updated"
+      description: "Number of student documents updated",
+      splitMetricByLabels: true
     }
-    const labels: MetricLabel[] = [
-      ["schoolNumber", documentUpdate.school.schoolNumber],
-      ["templateName", documentUpdate.template.name]
-    ]
+    const labels: MetricLabel[] = [["schoolNumber", documentUpdate.school.schoolNumber]]
 
     if (!updatedDocument?._id) {
       incrementCount({
@@ -1418,12 +1416,19 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "DocumentTemplate_Create",
-      description: "Number of document templates created"
+      description: "Number of document templates created",
+      splitMetricByLabels: true,
+      includeLabelsInSplit: false
     }
-    const labels: MetricLabel[] = [
-      ["availableForClasses", template.availableForDocumentType.group.toString()],
-      ["availableForStudents", template.availableForDocumentType.student.toString()]
-    ]
+    const labels: MetricLabel[] = []
+
+    if (template.availableForDocumentType.group) {
+      labels.push(["availableForClasses", template.availableForDocumentType.group.toString()])
+    }
+
+    if (template.availableForDocumentType.student) {
+      labels.push(["availableForStudents", template.availableForDocumentType.student.toString()])
+    }
 
     if (!result.insertedId) {
       incrementCount({
@@ -1452,12 +1457,19 @@ export class MongoDbClient implements IDbClient {
 
     const metricBody: MetricCount = {
       name: "DocumentTemplate_Update",
-      description: "Number of document templates updated"
+      description: "Number of document templates updated",
+      splitMetricByLabels: true,
+      includeLabelsInSplit: false
     }
-    const labels: MetricLabel[] = [
-      ["availableForClasses", template.availableForDocumentType.group.toString()],
-      ["availableForStudents", template.availableForDocumentType.student.toString()]
-    ]
+    const labels: MetricLabel[] = []
+
+    if (template.availableForDocumentType.group) {
+      labels.push(["availableForClasses", template.availableForDocumentType.group.toString()])
+    }
+
+    if (template.availableForDocumentType.student) {
+      labels.push(["availableForStudents", template.availableForDocumentType.student.toString()])
+    }
 
     if (result.modifiedCount === 0) {
       incrementCount({

--- a/src/lib/server/metrics/handle-metrics.ts
+++ b/src/lib/server/metrics/handle-metrics.ts
@@ -1,5 +1,5 @@
 import { count, gauge } from "@vestfoldfylke/vestfold-metrics"
-import type { MetricCount, MetricGauge } from "$lib/types/db/shared-types"
+import type { MetricCount, MetricGauge, MetricLabel } from "$lib/types/db/shared-types"
 
 const metricNamePrefix = "Elevoppfolging_"
 
@@ -19,6 +19,10 @@ export const updateGauge = (metricGauge: MetricGauge): void => {
 }
 
 export const incrementCount = (metricCount: MetricCount): void => {
+  if (handleCountSplitMetricByLabels(metricCount)) {
+    return
+  }
+
   const metricName: string = `${metricNamePrefix}${metricCount.name}`
 
   if (metricCount.labels && metricCount.labels.length > 0) {
@@ -27,4 +31,42 @@ export const incrementCount = (metricCount: MetricCount): void => {
   }
 
   count(metricName, metricCount.description)
+}
+
+const handleCountSplitMetricByLabels = (metricCount: MetricCount): boolean => {
+  if (metricCount.splitMetricByLabels === undefined || !metricCount.splitMetricByLabels) {
+    return false
+  }
+
+  const customMetricLabels: MetricLabel[] = metricCount.labels?.filter((label: MetricLabel) => label[0] !== metricResultName) || []
+
+  if (customMetricLabels.length === 0) {
+    return false
+  }
+
+  const resultMetricLabel: MetricLabel | undefined = metricCount.labels?.find((label: MetricLabel) => label[0] === metricResultName)
+
+  customMetricLabels.forEach((label: MetricLabel) => {
+    const metricName: string = `${metricNamePrefix}${metricCount.name}_By_${label[0]}`
+    const metricDescription: string = `${metricCount.description} for ${label[0]}`
+
+    if (metricCount.includeLabelsInSplit === undefined || metricCount.includeLabelsInSplit) {
+      if (resultMetricLabel !== undefined) {
+        count(metricName, metricDescription, ...[label, resultMetricLabel])
+        return
+      }
+
+      count(metricName, metricDescription, label)
+      return
+    }
+
+    if (resultMetricLabel !== undefined) {
+      count(metricName, metricDescription, resultMetricLabel)
+      return
+    }
+
+    count(metricName, metricDescription)
+  })
+
+  return true
 }

--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -628,9 +628,22 @@ export type DbStudentDataSharingConsent = StudentDataSharingConsentBase &
 export type MetricLabel = [labelName: string, labelValue: string]
 
 export type MetricCount = {
+  /** Will be the visible name in Prometheus.<br />
+   *  A system-wide prefix will be added. See <b>metricNamePrefix</b> in handle-metrics.ts.<br />
+   *  If <u>splitMetricByLabels</u> is true, "\_By\_%labelName%" will be appended */
   name: string
+  /** If <u>splitMetricByLabels</u> is true, " for %labelName%" will be appended */
   description: string
   labels?: MetricLabel[]
+  /** If set to true, the metric will be split into <u>x</u> metrics (<u>x</u> is the number of labels present (<b>metricResultName</b> not counted)) and "\_By\_%labelName%" will be appended to the metric name.<br />
+   *  If not set or set to false, all labels will be added to the metric as is.<br />
+   *  Default behavior: false*/
+  splitMetricByLabels?: boolean
+  /** Only applicable when <u>splitMetricByLabels</u> is <b>true</b>.<br />
+   *  If set to false, labels will not be added to the metric (<b>metricResultName</b> will be added anyway).<br />
+   *  If not set or set to true, splitted labels will be added to the metric (<b>metricResultName</b> will be added anyway).<br />
+   *  Default behavior: true */
+  includeLabelsInSplit?: boolean
 }
 
 export type MetricGauge = {


### PR DESCRIPTION
### Patch commits:
- fix: Introduced `splitMetricByLabels` and `includeLabelsInSplit` for more control when multiple labels are present. Multiple labels can make it difficult in Prometheus to see the actual increase. Also added JSDoc to the MetricCount properties (3209def)

### Maintenance commits:
- chore: Use the shared type instead of inline type (68e369e)
