### PR TITLE
patch: 1.0.0 - consent-validation-and-pretty

### DIFF
--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -141,7 +141,7 @@
   }
 
   .message-block:nth-child(odd) {
-    background-color: var(--ds-color-background-tinted);
+    background-color: var(--ds-color-surface-tinted);
   }
 
   .message-header {

--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api-fetch/api-fetch"
+  import { studentDataSharingConsentMessageValidation } from "$lib/data-validation/student-consent-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { FrontendStudent, StudentUnavailableSchoolDocuments } from "$lib/types/app-types"
@@ -81,7 +82,7 @@
           <div data-field="description">
             Hvor er samtykket dokumentert, eventuelt annen relevant informasjon om samtykket
           </div>
-          <textarea id="sharing-consent-message" rows="4" bind:value={editableSharingConsent.message} class="ds-input"></textarea>
+          <textarea id="sharing-consent-message" rows="4" required={editableSharingConsent.consent} minlength={editableSharingConsent.consent ? studentDataSharingConsentMessageValidation.minLength : 0} maxlength={studentDataSharingConsentMessageValidation.maxLength} bind:value={editableSharingConsent.message} class="ds-input"></textarea>
         </ds-field>
       </form>
     {:else}

--- a/src/lib/data-validation/student-consent-validation.ts
+++ b/src/lib/data-validation/student-consent-validation.ts
@@ -10,12 +10,14 @@ export const validateStudentDataSharingConsentData = (consentData: StudentDataSh
   if (typeof consentData.consent !== "boolean") {
     return { valid: false, message: "'consent' must be a boolean" }
   }
-  if (
-    typeof consentData.message !== "string" ||
-    consentData.message.length < studentDataSharingConsentMessageValidation.minLength ||
-    consentData.message.length > studentDataSharingConsentMessageValidation.maxLength
-  ) {
-    return { valid: false, message: `'message' must be between ${studentDataSharingConsentMessageValidation.minLength} and ${studentDataSharingConsentMessageValidation.maxLength} characters` }
+  if (typeof consentData.message !== "string") {
+    return { valid: false, message: "'message' must be a string" }
+  }
+  if (consentData.consent && consentData.message.trim().length === 0) {
+    return { valid: false, message: "'message' cannot be empty when consent is given" }
+  }
+  if (consentData.message.length > studentDataSharingConsentMessageValidation.maxLength) {
+    return { valid: false, message: `'message' cannot be longer than ${studentDataSharingConsentMessageValidation.maxLength} characters` }
   }
 
   return { valid: true, message: "" }

--- a/src/routes/api/classes/[system_id]/importantstuff/+server.ts
+++ b/src/routes/api/classes/[system_id]/importantstuff/+server.ts
@@ -41,7 +41,7 @@ const updateGroupImportantStuff: ApiNextFunction<PatchGroupImportantStuffRespons
   const validationResult = validateGroupImportantStuffData(groupImportantStuffData)
 
   if (!validationResult.valid) {
-    throw new HTTPError(400, "Invalid request body", { details: validationResult.message })
+    throw new HTTPError(400, `Invalid request body: ${validationResult.message}`)
   }
 
   const dbClient = getDbClient()

--- a/src/routes/api/students/[student_id]/consent/+server.ts
+++ b/src/routes/api/students/[student_id]/consent/+server.ts
@@ -44,7 +44,7 @@ const updateStudentDataSharingConsent: ApiNextFunction<PatchConsentResponse, Pat
   const validationResult = validateStudentDataSharingConsentData(body)
 
   if (!validationResult.valid) {
-    throw new HTTPError(400, "Invalid request body", { details: validationResult.message })
+    throw new HTTPError(400, `Invalid request body: ${validationResult.message}`)
   }
 
   const upsertConsentData: NewStudentDataSharingConsent = {

--- a/src/routes/api/students/[student_id]/importantstuff/+server.ts
+++ b/src/routes/api/students/[student_id]/importantstuff/+server.ts
@@ -42,7 +42,7 @@ const updateStudentImportantStuff: ApiNextFunction<PatchImportantStuffResponse, 
   const validationResult = validateStudentImportantStuffData(studentImportantStuffData)
 
   if (!validationResult.valid) {
-    throw new HTTPError(400, "Invalid request body", { details: validationResult.message })
+    throw new HTTPError(400, `Invalid request body: ${validationResult.message}`)
   }
 
   const canEditImportantStuff = canEditStudentImportantStuff(studentImportantStuffData.school.schoolNumber, principalAccessForStudent)


### PR DESCRIPTION
### Patch commits:
- fix: not so dvask background-color on nth-child message (213d754)
- fix: include validation message in errormessage (54ad5d3)
- fix: allow empty message when consent is false (d29fae3)
