### PR TITLE
patch: 1.0.0 - adressesperre-more-visible

### DIFF
--- a/src/routes/students/[student_id]/+page.svelte
+++ b/src/routes/students/[student_id]/+page.svelte
@@ -180,7 +180,7 @@
     <h1 class="ds-heading" data-size="lg" style="margin-bottom: 0;">{data.student.name}</h1>
     <span class="ds-paragraph" data-size="sm">{studentEnrollmentDetails.length > 1 ? "Hovedskole: " : ""}{studentMainDetails.mainSchool?.name ?? "Ingen hovedskole"} - {studentMainDetails.mainClass?.name || "Ingen aktiv klasse ved hovedskole"}</span>
     {#if data.student.hasBlockedAddress}
-      <div class="ds-alert address-block-container" data-color="info">
+      <div class="ds-alert address-block-container" data-color="warning">
         NB: Adressesperre
       </div>
     {/if}


### PR DESCRIPTION
### Maintenance commits:
- chore: Use a stronger color to show that the student has an address block (92da1ba)
