### PR TITLE
patch: 1.0.0 - enda-mere-pynt

### DIFF
--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -176,7 +176,7 @@
         </div>
 
         {#if !editMode}
-          <h2 class="ds-heading">{editableDocument.title}</h2>
+          <h2 class="ds-heading" style="font-weight: bold;">{editableDocument.title}</h2>
           <EditorInfo editorInfo={document.created} isEdited={document.modified.at.getTime() > document.created.at.getTime()} timestamp={true} modifiedIndicator={true} />
         {/if}
       </div>
@@ -251,7 +251,7 @@
   }
 
   .document-dialog-header-tags {
-    margin-bottom: var(--ds-size-2);
+    margin-bottom: var(--ds-size-4);
   }
 
   .message-container {

--- a/src/lib/components/Document/DocumentContentItem.svelte
+++ b/src/lib/components/Document/DocumentContentItem.svelte
@@ -175,9 +175,9 @@
         <input autocomplete="off" class="ds-input" type="text" id={contentItem.label} name={`contentItem-${index}`} placeholder={contentItem.placeholder} bind:value={contentItem.value} required={contentItem.required} />
       {/if}
     </ds-field>
-  {:else}
-    <div class="ds-field content-item">
-    <div class="ds-label" data-weight="medium">{contentItem.label}</div>
+  {:else if contentItem.required || contentItem.value.trim()}
+    <div class="content-item">
+      <div class="ds-label bold" data-weight="medium">{contentItem.label}</div>
     {@render helpText(contentItem)}
     <p class="ds-paragraph">{contentItem.value}</p>
     </div>
@@ -200,7 +200,7 @@
     </ds-field>
   {:else}
     <div class="ds-field content-item">
-      <div class="ds-label" data-weight="medium">{contentItem.label}</div>
+      <div class="ds-label bold" data-weight="medium">{contentItem.label}</div>
       {@render helpText(contentItem)}
       <p class="ds-paragraph pre-wrap-whitespace">{contentItem.value}</p>
     </div>
@@ -209,7 +209,7 @@
 
 {#if contentItem.type === "radioGroup"}
   <fieldset class="ds-fieldset content-item">
-    <legend class="ds-label" data-weight="medium">
+    <legend class="ds-label" class:bold={!editMode} data-weight="medium">
       {contentItem.header}
       {@render requiredIndicator(true, "Velg ett alternativ")}
     </legend>
@@ -231,7 +231,7 @@
 
 {#if contentItem.type === "checkboxGroup"}
   <fieldset class="ds-fieldset content-item">
-    <legend class="ds-label" data-weight="medium">
+    <legend class="ds-label" class:bold={!editMode} data-weight="medium">
       {contentItem.header}
       {@render requiredIndicator(true, "Minst et valg")}
     </legend>
@@ -252,6 +252,10 @@
 {/if}
 
 <style>
+  .bold {
+    font-weight: bold;
+  }
+
   .pre-wrap-whitespace {
     white-space: pre-wrap;
   }

--- a/src/lib/components/Document/DocumentContentItem.svelte
+++ b/src/lib/components/Document/DocumentContentItem.svelte
@@ -116,7 +116,7 @@
 </script>
 
 {#snippet helpText(inputItem: DocumentInputItem)}
-  {#if inputItem.helpText}
+  {#if editMode && inputItem.helpText}
     <div data-field="description">
       {inputItem.helpText}
     </div>
@@ -142,7 +142,7 @@
 {/if}
 
 {#if contentItem.type === "info" && (editMode || previewMode)}
-  <div class="ds-card content-item" data-variant="tinted" data-color="accent">
+  <div class="ds-alert content-item" data-color="info">
     <p class="ds-paragraph pre-wrap-whitespace">
       {#each parseInfoItemValue(contentItem.value) as infoItem}
         {#if infoItem.type === "text"}
@@ -152,12 +152,6 @@
         {/if}
       {/each}
     </p>
-    <!--
-    <p class="ds-paragraph pre-wrap-whitespace">{contentItem.value}</p>
-    {#if contentItem.link && contentItem.link.url && contentItem.link.text}
-      <a class="ds-link" href={contentItem.link.url} target="_blank" rel="noopener noreferrer">{contentItem.link.text}</a>
-    {/if}
-    -->
   </div>
 {/if}
 
@@ -178,8 +172,8 @@
   {:else if contentItem.required || contentItem.value.trim()}
     <div class="content-item">
       <div class="ds-label bold" data-weight="medium">{contentItem.label}</div>
-    {@render helpText(contentItem)}
-    <p class="ds-paragraph">{contentItem.value}</p>
+      {@render helpText(contentItem)}
+      <p class="ds-paragraph">{contentItem.value}</p>
     </div>
   {/if}
 {/if}
@@ -198,8 +192,8 @@
         <textarea class="ds-input" id={contentItem.label} name="contentItem-{index}" rows={contentItem.initialRows} placeholder={contentItem.placeholder} required={contentItem.required} bind:value={contentItem.value}></textarea>
       {/if}
     </ds-field>
-  {:else}
-    <div class="ds-field content-item">
+  {:else if contentItem.required || contentItem.value.trim()}
+    <div class="content-item">
       <div class="ds-label bold" data-weight="medium">{contentItem.label}</div>
       {@render helpText(contentItem)}
       <p class="ds-paragraph pre-wrap-whitespace">{contentItem.value}</p>

--- a/src/lib/components/Document/DocumentEditor.svelte
+++ b/src/lib/components/Document/DocumentEditor.svelte
@@ -136,16 +136,31 @@
       </ds-field>
     {/if}
 
-    <ds-field class="ds-field content-item">
-      <label for="documentTitle" class="ds-label" data-weight="medium">
-        Tittel
-        <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
-      </label>
-      <input autocomplete="off" id="documentTitle" class="ds-input" name="documentTitle" type="text" bind:value={currentDocument.title} required>
-    </ds-field>
+    {#each currentDocument.content as contentItem, index}
+      <!-- If first element is info - we want to display it before the title for nicer UX. Else, we display title of document as first element -->
+      {#if index === 0}
+        {#if contentItem.type === "info"}
+          <DocumentContentItem bind:contentItem={currentDocument.content[0]} {index} editMode={true} />
+        {/if}
 
-    {#each currentDocument.content as _contentItem, index}
-      <DocumentContentItem bind:contentItem={currentDocument.content[index]} {index} editMode={true} />
+        <ds-field class="ds-field content-item">
+          <label for="documentTitle" class="ds-label" data-weight="medium">
+            Tittel
+            <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
+          </label>
+          <div data-field="description">
+            En kort og beskrivende tittel på notatet. Tittelen vil være det som vises i oversikten over notater.
+          </div>
+          <input autocomplete="off" id="documentTitle" class="ds-input" name="documentTitle" type="text" bind:value={currentDocument.title} required>
+        </ds-field>
+
+        {#if contentItem.type !== "info"}
+          <DocumentContentItem bind:contentItem={currentDocument.content[0]} {index} editMode={true} />
+        {/if}
+      {:else}
+        <!-- For other content items we just display them in order -->
+        <DocumentContentItem bind:contentItem={currentDocument.content[index]} {index} editMode={true} />
+      {/if}
     {/each}
 
     {#if studentId}

--- a/src/lib/components/Document/NewMessage.svelte
+++ b/src/lib/components/Document/NewMessage.svelte
@@ -50,7 +50,7 @@
 
 {#if messageType === null}
   <div class="new-message-actions">
-    <button class="ds-button" data-variant="primary" data-size="sm" onclick={() => { messageType = "update"; scrollToNewMessage(); }}><span class="material-symbols-outlined">info</span>Ny oppdatering</button>
+    <button class="ds-button" data-variant="primary" data-size="sm" onclick={() => { messageType = "update"; scrollToNewMessage(); }}><span class="material-symbols-outlined">chat_info</span>Ny oppdatering</button>
   </div>
 {:else}
   <div id="new-message-container">

--- a/src/lib/components/TemplateEditor/TemplateEditor.svelte
+++ b/src/lib/components/TemplateEditor/TemplateEditor.svelte
@@ -38,16 +38,16 @@
     },
     {
       type: "inputText",
-      placeholder: "Heisann",
+      placeholder: "",
       label: "Beskrivelse av tekstfelt",
-      helpText: "",
+      helpText: "En hjelpende tekst som forklarer mer om hva som skal fylles ut i tekstfeltet",
       value: "",
       required: true
     },
     {
       type: "textarea",
       label: "Beskrivelse av tekstområde",
-      helpText: "",
+      helpText: "En hjelpende tekst som forklarer mer om hva som skal fylles ut i tekstområdet",
       placeholder: "",
       value: "",
       initialRows: 3,


### PR DESCRIPTION
### Patch commits:
- fix: better default values for input fields in template (8da49ab)
- fix: consistent use of icon for message (1dab546)
- fix: show document info before title, of document info is first in template (02171cf)
- fix: only show descriptions when editing, and hide optional fields when not filled out when not in edit mode (0291792)
- fix: more contrasted titles (a9edc33)

### Other commits:
- Merge remote-tracking branch 'origin/main' into enda-mere-pynt (8664eaf)
