### PR TITLE
minor: 1.0.0 - encryption-client-students

### DIFF
--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -123,7 +123,6 @@
 
   .ds-card {
     flex: 1;
-    min-width: 20rem;
+    min-width: 25rem;
   }
-
 </style>

--- a/src/lib/server/db/get-db-client.ts
+++ b/src/lib/server/db/get-db-client.ts
@@ -77,6 +77,15 @@ if (env.MOCK_DB === "true") {
     throw error
   }
 
+  if (encryptionKeyIds.length === 0) {
+    logger.error("No encryption keys found in MongoDB")
+    await logger.flush()
+
+    await mongoEncryptionClient.close()
+
+    throw new Error("No encryption keys found in MongoDB")
+  }
+
   const encryptValue = async (value: unknown): Promise<Binary> => {
     const encryptionOptions: ClientEncryptionEncryptOptions = {
       algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Random",

--- a/src/lib/server/db/get-db-client.ts
+++ b/src/lib/server/db/get-db-client.ts
@@ -71,6 +71,9 @@ if (env.MOCK_DB === "true") {
   } catch (error) {
     logger.errorException(error, "Error when fetching encryption keys from MongoDB, check your configuration")
     await logger.flush()
+
+    await mongoEncryptionClient.close()
+
     throw error
   }
 

--- a/src/lib/server/db/get-db-client.ts
+++ b/src/lib/server/db/get-db-client.ts
@@ -50,11 +50,8 @@ if (env.MOCK_DB === "true") {
     }
   })
 
-  const mongoClient = new MongoClient(env.MONGODB_CONNECTION_STRING)
-
   try {
     await mongoEncryptionClient.connect()
-    await mongoClient.connect()
   } catch (error) {
     logger.errorException(error, "Error when connecting to MongoDB - check your configuration")
     await logger.flush()
@@ -62,7 +59,6 @@ if (env.MOCK_DB === "true") {
   }
 
   const dbWithEncryption = mongoEncryptionClient.db(env.MONGODB_DATABASE_NAME)
-  const dbWithoutEncryption = mongoClient.db(env.MONGODB_DATABASE_NAME)
 
   const encryptionClient = new ClientEncryption(mongoEncryptionClient, {
     keyVaultNamespace: keyVaultNamespace,
@@ -87,18 +83,18 @@ if (env.MOCK_DB === "true") {
   }
 
   dbClient = {
-    appUsers: new AppUsersDbClient(dbWithoutEncryption),
-    access: new AccessDbClient(dbWithoutEncryption),
-    auditLogs: new AuditLogsDbClient(dbWithoutEncryption),
-    documentContentTemplates: new DocumentContentTemplatesDbClient(dbWithoutEncryption),
+    appUsers: new AppUsersDbClient(dbWithEncryption),
+    access: new AccessDbClient(dbWithEncryption),
+    auditLogs: new AuditLogsDbClient(dbWithEncryption),
+    documentContentTemplates: new DocumentContentTemplatesDbClient(dbWithEncryption),
     documents: new DocumentsDbClient(dbWithEncryption, encryptValue),
-    emailAlerts: new EmailAlertsDbClient(dbWithoutEncryption),
+    emailAlerts: new EmailAlertsDbClient(dbWithEncryption),
     importantStuff: new ImportantStuffDbClient(dbWithEncryption, encryptValue),
-    programAreas: new ProgramAreasDbClient(dbWithoutEncryption),
-    schools: new SchoolsDbClient(dbWithoutEncryption),
+    programAreas: new ProgramAreasDbClient(dbWithEncryption),
+    schools: new SchoolsDbClient(dbWithEncryption),
     studentCheckBoxes: new StudentCheckBoxDbClient(dbWithEncryption, encryptValue),
-    studentDataSharingConsents: new StudentDataSharingConsentsDbClient(dbWithoutEncryption),
-    students: new StudentsDbClient(dbWithoutEncryption)
+    studentDataSharingConsents: new StudentDataSharingConsentsDbClient(dbWithEncryption),
+    students: new StudentsDbClient(dbWithEncryption)
   }
 }
 

--- a/src/lib/server/db/get-db-client.ts
+++ b/src/lib/server/db/get-db-client.ts
@@ -106,7 +106,7 @@ if (env.MOCK_DB === "true") {
     schools: new SchoolsDbClient(dbWithEncryption),
     studentCheckBoxes: new StudentCheckBoxDbClient(dbWithEncryption, encryptValue),
     studentDataSharingConsents: new StudentDataSharingConsentsDbClient(dbWithEncryption),
-    students: new StudentsDbClient(dbWithEncryption)
+    students: new StudentsDbClient(dbWithEncryption, encryptValue)
   }
 }
 

--- a/src/lib/server/db/mongo/students-db-client.ts
+++ b/src/lib/server/db/mongo/students-db-client.ts
@@ -1,20 +1,25 @@
 import { logger } from "@vestfoldfylke/loglady"
-import { type Collection, type Db, type InsertOneResult, ObjectId, type UpdateResult, type WithId } from "mongodb"
+import { type Binary, type Db, type InsertOneResult, ObjectId, type UpdateResult, type WithId } from "mongodb"
 import type { FrontendStudent } from "$lib/types/app-types"
 import type { IStudentsDbClient } from "$lib/types/db/db-client"
 import type { KeysToNumber } from "$lib/types/db/db-helpers"
-import type { AppStudent, DbAppStudent, MetricCount, MetricLabel, NewAppStudent, StudentEnrollment, UpdateAppStudent } from "$lib/types/db/shared-types"
+import type { AppStudent, DbAppStudent, DbEncryptedAppStudent, MetricCount, MetricLabel, NewAppStudent, StudentEnrollment, UpdateAppStudent } from "$lib/types/db/shared-types"
 import { APP_INFO } from "../../app-info"
 import { incrementCount, metricResultFailure, metricResultName, metricResultSuccessful } from "../../metrics/handle-metrics"
 
 export class StudentsDbClient implements IStudentsDbClient {
-  private studentsCollection: Collection<NewAppStudent>
+  private encryptionDb: Db
+  private readonly encryptValue: (value: unknown) => Promise<Binary>
+  private readonly studentsCollectionName: string = "students"
 
-  constructor(db: Db) {
-    this.studentsCollection = db.collection<NewAppStudent>("students")
+  constructor(db: Db, encryptValue: (value: unknown) => Promise<Binary>) {
+    this.encryptionDb = db
+    this.encryptValue = encryptValue
   }
 
   async getAllStudents(): Promise<FrontendStudent[]> {
+    const studentsCollection = this.encryptionDb.collection<DbAppStudent>(this.studentsCollectionName)
+
     const projection: KeysToNumber<WithId<FrontendStudent>> = {
       _id: 1,
       feideName: 1,
@@ -32,7 +37,7 @@ export class StudentsDbClient implements IStudentsDbClient {
     endDateMustBeAfter.setDate(endDateMustBeAfter.getDate() - APP_INFO.STUDENT_ACCESS_AFTER_EXPIRE_DAYS)
 
     // Get all students that has an enrollment with end date after the today minus STUDENT_ACCESS_AFTER_EXPIRE_DAYS, or no end date at all (active enrollments)
-    const students = await this.studentsCollection
+    const students = await studentsCollection
       .find<FrontendStudent>({ $or: [{ "studentEnrollments.period.end": { $eq: null } }, { "studentEnrollments.period.end": { $gte: endDateMustBeAfter } }] }, { projection })
       .toArray()
 
@@ -43,6 +48,8 @@ export class StudentsDbClient implements IStudentsDbClient {
   }
 
   async getStudentBySsn(ssn: string): Promise<FrontendStudent | null> {
+    const studentsCollection = this.encryptionDb.collection<DbAppStudent>(this.studentsCollectionName)
+
     logger.info("Getting student by ssn")
 
     const projection: KeysToNumber<WithId<FrontendStudent>> = {
@@ -58,7 +65,7 @@ export class StudentsDbClient implements IStudentsDbClient {
       hasBlockedAddress: 1
     }
 
-    const student: WithId<DbAppStudent> | null = await this.studentsCollection.findOne({ ssn }, { projection })
+    const student: DbAppStudent | null = await studentsCollection.findOne({ ssn }, { projection })
     if (!student) {
       return null
     }
@@ -80,6 +87,8 @@ export class StudentsDbClient implements IStudentsDbClient {
   }
 
   async getManualStudentById(studentId: string): Promise<AppStudent | null> {
+    const studentsCollection = this.encryptionDb.collection<DbAppStudent>(this.studentsCollectionName)
+
     logger.info("Getting manual student by id")
 
     const projection: KeysToNumber<WithId<AppStudent>> = {
@@ -96,7 +105,7 @@ export class StudentsDbClient implements IStudentsDbClient {
       hasBlockedAddress: 1
     }
 
-    const student: WithId<DbAppStudent> | null = await this.studentsCollection.findOne({ _id: new ObjectId(studentId), source: "MANUAL" }, { projection })
+    const student: DbAppStudent | null = await studentsCollection.findOne({ _id: new ObjectId(studentId), source: "MANUAL" }, { projection })
     if (!student) {
       return null
     }
@@ -119,9 +128,19 @@ export class StudentsDbClient implements IStudentsDbClient {
   }
 
   async createManualStudent(manualStudent: NewAppStudent): Promise<string> {
+    const studentsCollection = this.encryptionDb.collection<DbEncryptedAppStudent>(this.studentsCollectionName)
+
     logger.info("Creating new manual student with systemId: {SystemId}", manualStudent.systemId)
 
-    const result: InsertOneResult<DbAppStudent> = await this.studentsCollection.insertOne(manualStudent)
+    const encryptedHasBlockedAddress: Binary = await this.encryptValue(manualStudent.hasBlockedAddress ?? false)
+
+    const encryptedManualStudent: DbEncryptedAppStudent = {
+      ...manualStudent,
+      _id: new ObjectId(),
+      hasBlockedAddress: encryptedHasBlockedAddress
+    }
+
+    const result: InsertOneResult<DbEncryptedAppStudent> = await studentsCollection.insertOne(encryptedManualStudent)
 
     const mainSchoolNumber: string | undefined = manualStudent.studentEnrollments.find((enrollment: StudentEnrollment) => enrollment.mainSchool)?.school.schoolNumber
     const metricBody: MetricCount = {
@@ -152,14 +171,19 @@ export class StudentsDbClient implements IStudentsDbClient {
   }
 
   async updateManualStudent(manualStudent: UpdateAppStudent): Promise<string> {
+    const studentsCollection = this.encryptionDb.collection<DbEncryptedAppStudent>(this.studentsCollectionName)
+
     logger.info("Updating manual student with Id: {Id}", manualStudent._id)
 
-    const manualStudentWithId: DbAppStudent = {
+    const encryptedHasBlockedAddress: Binary = await this.encryptValue(manualStudent.hasBlockedAddress ?? false)
+
+    const manualStudentWithId: DbEncryptedAppStudent = {
       ...manualStudent,
-      _id: new ObjectId(manualStudent._id)
+      _id: new ObjectId(manualStudent._id),
+      hasBlockedAddress: encryptedHasBlockedAddress
     }
 
-    const result: UpdateResult<DbAppStudent> = await this.studentsCollection.updateOne({ _id: new ObjectId(manualStudent._id) }, { $set: manualStudentWithId })
+    const result: UpdateResult<DbEncryptedAppStudent> = await studentsCollection.updateOne({ _id: manualStudentWithId._id }, { $set: manualStudentWithId })
 
     const mainSchoolNumber: string | undefined = manualStudent.studentEnrollments.find((enrollment: StudentEnrollment) => enrollment.mainSchool)?.school.schoolNumber
     const metricBody: MetricCount = {

--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -132,6 +132,10 @@ export type DbAppStudent = NewAppStudent & {
   _id: ObjectId
 }
 
+export type DbEncryptedAppStudent = Omit<DbAppStudent, "hasBlockedAddress"> & {
+  hasBlockedAddress: Binary
+}
+
 export type UpdateAppStudent = AppStudent
 
 export type NewManualStudentInput = {

--- a/src/routes/students/[student_id]/+page.svelte
+++ b/src/routes/students/[student_id]/+page.svelte
@@ -286,7 +286,7 @@
       <div class="consent-and-access-container">
         <DataSharingConsent canEdit={canEditStudentDataSharingConsent(data.principalAccessForStudent)} student={data.student} studentDataSharingConsent={data.studentDataSharingConsent} unavailableSchoolDocuments={data.unavailableSchoolDocuments} />
         
-        <div class="ds-card" data-variant="tinted" data-color="brand2">
+        <div class="ds-card access-container" data-variant="tinted" data-color="brand2">
           <div class="card-header">
             <div class="card-title">
               <span class="material-symbols-outlined">school</span>
@@ -457,6 +457,10 @@
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
+  }
+
+  .access-container {
+    flex: 3;
   }
 
   .documents {


### PR DESCRIPTION
### Minor commits:
- feat: Encrypt `hasBlockedAddress` on manual students when creating and updating (2f0e7a2)

### Patch commits:
- fix: `Skolesamarbeid` should not get any smaller than **25rem** (1e4c50f)
- fix: If `getKeys()` successfully returns 0 keys, stop execution (99cb985)
- fix: close client if any errors on startup (aa7c860)

### Maintenance commits:
- chore: Removed unneccesarry `mongoClient`. We can use `mongoEncryptionClient` for collections with and without decryption needs (ce991bb)
