### PR TITLE
minor: 1.0.0 - asyncbutton-return-types

### DIFF
--- a/src/lib/components/AsyncButton.svelte
+++ b/src/lib/components/AsyncButton.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { invalidateAll } from "$app/navigation"
 
-  export type SuccessResult = { status: 'success'; reloadPageData?: boolean; callBack?: () => void }
-  export type CancelResult = { status: 'cancelled', callBack?: () => void }
-  export type ErrorResult = { status: 'error'; message: string }
+  export type SuccessResult = { status: "success"; reloadPageData?: boolean; callBack?: () => void }
+  export type CancelResult = { status: "cancelled"; callBack?: () => void }
+  export type ErrorResult = { status: "error"; message: string }
   export type AsyncButtonResult = SuccessResult | CancelResult | ErrorResult
 
   type AsyncButtonProps = {
@@ -16,15 +16,7 @@
     disabled?: boolean
   }
 
-  let {
-    buttonText,
-    onClick,
-    iconName,
-    variant = "primary",
-    color = "accent",
-    dataSize = "md",
-    disabled = false
-  }: AsyncButtonProps = $props()
+  let { buttonText, onClick, iconName, variant = "primary", color = "accent", dataSize = "md", disabled = false }: AsyncButtonProps = $props()
 
   type ButtonState = {
     loading: boolean
@@ -59,21 +51,21 @@
       const result = await onClick()
 
       switch (result.status) {
-        case 'cancelled':
+        case "cancelled":
           result.callBack?.()
           return
 
-        case 'error':
+        case "error":
           buttonState.errorMessage = result.message
           return
 
-        case 'success':
+        case "success":
           if (result.reloadPageData) {
-             await invalidateAll()
+            await invalidateAll()
           }
           result.callBack?.()
           return
-          
+
         default: {
           const _exhaustive: never = result
           throw new Error(`Unhandled AsyncButtonResult status: ${JSON.stringify(_exhaustive)}`)

--- a/src/lib/components/AsyncButton.svelte
+++ b/src/lib/components/AsyncButton.svelte
@@ -65,11 +65,6 @@
           }
           result.callBack?.()
           return
-
-        default: {
-          const _exhaustive: never = result
-          throw new Error(`Unhandled AsyncButtonResult status: ${JSON.stringify(_exhaustive)}`)
-        }
       }
     } catch (error) {
       buttonState.errorMessage = error instanceof Error ? error.message : "An error occurred. Please try again."

--- a/src/lib/components/AsyncButton.svelte
+++ b/src/lib/components/AsyncButton.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
   import { invalidateAll } from "$app/navigation"
 
+  export type SuccessResult = { status: 'success'; reloadPageData?: boolean; callBack?: () => void }
+  export type CancelResult = { status: 'cancelled', callBack?: () => void }
+  export type ErrorResult = { status: 'error'; message: string }
+  export type AsyncButtonResult = SuccessResult | CancelResult | ErrorResult
+
   type AsyncButtonProps = {
     buttonText: string
-    onClick: () => Promise<void>
+    onClick: () => Promise<AsyncButtonResult>
     variant?: "primary" | "secondary" | "tertiary"
     color?: "accent" | "danger"
     dataSize?: "sm" | "md" | "lg"
     iconName?: string
-    reloadPageDataOnSuccess?: boolean
-    /** If you need anything to trigger after page data is reloaded (requires reloadPageDataOnSuccess to be true) */
-    callBackAfterReloadPageData?: () => void
-    errorMessage?: string
     disabled?: boolean
   }
 
@@ -22,9 +23,6 @@
     variant = "primary",
     color = "accent",
     dataSize = "md",
-    reloadPageDataOnSuccess = false,
-    callBackAfterReloadPageData,
-    errorMessage = $bindable(),
     disabled = false
   }: AsyncButtonProps = $props()
 
@@ -55,37 +53,37 @@
 
   const wrappedOnClick = async () => {
     buttonState.loading = true
-
     buttonState.errorMessage = null
-    if (typeof errorMessage === "string") {
-      errorMessage = ""
-    }
 
     try {
-      await onClick()
+      const result = await onClick()
 
-      if (!reloadPageDataOnSuccess) {
-        buttonState.loading = false
-        return
-      }
+      switch (result.status) {
+        case 'cancelled':
+          result.callBack?.()
+          return
 
-      await invalidateAll()
-      console.log("Page data invalidated successfully")
+        case 'error':
+          buttonState.errorMessage = result.message
+          return
 
-      if (callBackAfterReloadPageData) {
-        callBackAfterReloadPageData()
+        case 'success':
+          if (result.reloadPageData) {
+             await invalidateAll()
+          }
+          result.callBack?.()
+          return
+          
+        default: {
+          const _exhaustive: never = result
+          throw new Error(`Unhandled AsyncButtonResult status: ${JSON.stringify(_exhaustive)}`)
+        }
       }
     } catch (error) {
-      console.error("Error in AsyncButton onClick:", error)
-
       buttonState.errorMessage = error instanceof Error ? error.message : "An error occurred. Please try again."
-
-      if (typeof errorMessage === "string") {
-        errorMessage = buttonState.errorMessage
-      }
+    } finally {
+      buttonState.loading = false
     }
-
-    buttonState.loading = false
   }
 </script>
 

--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -176,6 +176,10 @@
   // svelte-ignore state_referenced_locally - det går bra så lenge denne komponenten remounts ved endring av document (ha en key på document i parent)
   let editableDocument: DocumentInput = $state(editableDocumentFromDocument())
 
+  let documentEdited: boolean = $derived.by(() => {
+    return JSON.stringify(editableDocumentFromDocument()) !== JSON.stringify(editableDocument)
+  })
+
   let editMode = $state(false)
 </script>
 
@@ -236,7 +240,7 @@
           {/each}
 
         {:else}
-          <DocumentEditor documentId={document._id} studentId={"student" in document ? document.student._id : undefined} groupSystemId={"group" in document ? document.group.systemId : undefined} bind:currentDocument={editableDocument} {accessSchools} closeEditor={() => { editMode = false; editableDocument = editableDocumentFromDocument(); }} />
+          <DocumentEditor documentId={document._id} studentId={"student" in document ? document.student._id : undefined} groupSystemId={"group" in document ? document.group.systemId : undefined} bind:currentDocument={editableDocument} {accessSchools} {documentEdited} closeEditor={() => { editMode = false; editableDocument = editableDocumentFromDocument(); }} />
         {/if}
 
         <div class="document-footer">

--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -141,7 +141,7 @@
   const handleDocumentRemove = async (): Promise<AsyncButtonResult> => {
     const confirmDelete = confirm("Er du heeeelt sikker på du vil slette dette notatet da? Notatet og alle tilhørende oppdateringer vil bli borte borte")
     if (!confirmDelete) {
-      return { status: 'cancelled' }
+      return { status: "cancelled" }
     }
 
     if (studentName && "student" in document) {
@@ -153,7 +153,7 @@
 
       documentDialog?.close()
 
-      return { status: 'success', reloadPageData: true }
+      return { status: "success", reloadPageData: true }
     }
 
     if (groupName && "group" in document) {
@@ -165,10 +165,10 @@
 
       documentDialog?.close()
 
-      return { status: 'success', reloadPageData: true }
+      return { status: "success", reloadPageData: true }
     }
 
-    return { status: 'error', message: 'Document was neither student or group document??' }
+    return { status: "error", message: "Document was neither student or group document??" }
   }
 
   // svelte-ignore state_referenced_locally - det går bra så lenge denne komponenten remounts ved endring av document (ha en key på document i parent)

--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte"
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentAccessPerson } from "$lib/types/app-types"
   import type { AuditEntryInput, DocumentInput, GroupDocument, MetricCount, SchoolInfo, StudentDocument } from "$lib/types/db/shared-types"
@@ -138,10 +138,10 @@
     })
   }
 
-  const handleDocumentRemove = async (): Promise<void> => {
+  const handleDocumentRemove = async (): Promise<AsyncButtonResult> => {
     const confirmDelete = confirm("Er du heeeelt sikker på du vil slette dette notatet da? Notatet og alle tilhørende oppdateringer vil bli borte borte")
     if (!confirmDelete) {
-      return
+      return { status: 'cancelled' }
     }
 
     if (studentName && "student" in document) {
@@ -151,11 +151,9 @@
         method: "DELETE"
       })
 
-      if (documentDialog) {
-        documentDialog.close()
-      }
+      documentDialog?.close()
 
-      return
+      return { status: 'success', reloadPageData: true }
     }
 
     if (groupName && "group" in document) {
@@ -165,12 +163,12 @@
         method: "DELETE"
       })
 
-      if (documentDialog) {
-        documentDialog.close()
-      }
+      documentDialog?.close()
 
-      return
+      return { status: 'success', reloadPageData: true }
     }
+
+    return { status: 'error', message: 'Document was neither student or group document??' }
   }
 
   // svelte-ignore state_referenced_locally - det går bra så lenge denne komponenten remounts ved endring av document (ha en key på document i parent)
@@ -280,7 +278,7 @@
                   </button>
                 {/if}
                 {#if canRemoveDocument}
-                  <AsyncButton buttonText="Slett notat" onClick={handleDocumentRemove} dataSize="sm" iconName="delete" color="danger" reloadPageDataOnSuccess={true} />
+                  <AsyncButton buttonText="Slett notat" onClick={handleDocumentRemove} dataSize="sm" iconName="delete" color="danger" />
                 {/if}
               </div>
             {/if}

--- a/src/lib/components/Document/DocumentEditor.svelte
+++ b/src/lib/components/Document/DocumentEditor.svelte
@@ -21,7 +21,18 @@
     closeEditor: () => void
   }
 
-  let { documentId, studentId, groupSystemId, accessSchools, currentDocument = $bindable(), studentDataSharingConsent, studentAccessPersons, emailAlertAvailable, documentEdited, closeEditor }: EditorProps = $props()
+  let {
+    documentId,
+    studentId,
+    groupSystemId,
+    accessSchools,
+    currentDocument = $bindable(),
+    studentDataSharingConsent,
+    studentAccessPersons,
+    emailAlertAvailable,
+    documentEdited,
+    closeEditor
+  }: EditorProps = $props()
 
   // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
   if (!studentId && !groupSystemId) {
@@ -40,12 +51,12 @@
 
   const newDocument = async (): Promise<AsyncButtonResult> => {
     if (!documentEditorForm) {
-      return { status: 'error', message: "Document editor form not found" }
+      return { status: "error", message: "Document editor form not found" }
     }
 
     const formIsValid = documentEditorForm.reportValidity()
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (groupSystemId) {
@@ -59,7 +70,7 @@
         }
       })
 
-      return { status: 'success', reloadPageData: true, callBack: closeEditor }
+      return { status: "success", reloadPageData: true, callBack: closeEditor }
     }
 
     if (studentId) {
@@ -74,21 +85,21 @@
       })
     }
 
-    return { status: 'success', reloadPageData: true, callBack: closeEditor }
+    return { status: "success", reloadPageData: true, callBack: closeEditor }
   }
 
   const updateDocument = async (): Promise<AsyncButtonResult> => {
     if (!documentId) {
-      return { status: 'error', message: "Document ID is required to update document" }
+      return { status: "error", message: "Document ID is required to update document" }
     }
 
     if (!documentEditorForm) {
-      return { status: 'error', message: "Document editor form not found" }
+      return { status: "error", message: "Document editor form not found" }
     }
 
     const formIsValid = documentEditorForm.reportValidity()
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (groupSystemId) {
@@ -102,7 +113,7 @@
         }
       })
 
-      return { status: 'success', reloadPageData: true, callBack: closeEditor }
+      return { status: "success", reloadPageData: true, callBack: closeEditor }
     }
 
     if (studentId) {
@@ -117,7 +128,7 @@
       })
     }
 
-    return { status: 'success', reloadPageData: true, callBack: closeEditor }
+    return { status: "success", reloadPageData: true, callBack: closeEditor }
   }
 </script>
 

--- a/src/lib/components/Document/DocumentEditor.svelte
+++ b/src/lib/components/Document/DocumentEditor.svelte
@@ -4,7 +4,7 @@
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentAccessPerson } from "$lib/types/app-types"
   import type { DocumentInput, SchoolInfo } from "$lib/types/db/shared-types"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
   import DocumentContentItem from "./DocumentContentItem.svelte"
   import EmailAlertSelector from "./EmailAlertSelector.svelte"
 
@@ -38,14 +38,14 @@
     currentDocument.documentAccess = currentDocument.documentAccess === "ALL_WITH_STUDENT_ACCESS" ? "EXCLUDE_SUBJECT_TEACHERS" : "ALL_WITH_STUDENT_ACCESS"
   }
 
-  const newDocument = async (): Promise<void> => {
+  const newDocument = async (): Promise<AsyncButtonResult> => {
     if (!documentEditorForm) {
-      throw new Error("Document editor form not found")
+      return { status: 'error', message: "Document editor form not found" }
     }
 
     const formIsValid = documentEditorForm.reportValidity()
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (groupSystemId) {
@@ -59,7 +59,7 @@
         }
       })
 
-      return
+      return { status: 'success', reloadPageData: true, callBack: closeEditor }
     }
 
     if (studentId) {
@@ -73,20 +73,22 @@
         }
       })
     }
+
+    return { status: 'success', reloadPageData: true, callBack: closeEditor }
   }
 
-  const updateDocument = async (): Promise<void> => {
+  const updateDocument = async (): Promise<AsyncButtonResult> => {
     if (!documentId) {
-      throw new Error("Document ID is required for updating a document")
+      return { status: 'error', message: "Document ID is required to update document" }
     }
 
     if (!documentEditorForm) {
-      throw new Error("Document editor form not found")
+      return { status: 'error', message: "Document editor form not found" }
     }
 
     const formIsValid = documentEditorForm.reportValidity()
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (groupSystemId) {
@@ -100,7 +102,7 @@
         }
       })
 
-      return
+      return { status: 'success', reloadPageData: true, callBack: closeEditor }
     }
 
     if (studentId) {
@@ -114,6 +116,8 @@
         }
       })
     }
+
+    return { status: 'success', reloadPageData: true, callBack: closeEditor }
   }
 </script>
 
@@ -201,10 +205,10 @@
 </div>
 <div class="document-actions">
   {#if !documentId}
-    <AsyncButton buttonText="Lagre notat" onClick={newDocument} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditor} iconName="save" />
+    <AsyncButton buttonText="Lagre notat" onClick={newDocument} iconName="save" />
   {/if}
   {#if documentId}
-    <AsyncButton disabled={!documentEdited} buttonText="Lagre endringer" onClick={updateDocument} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditor} iconName="save" />
+    <AsyncButton disabled={!documentEdited} buttonText="Lagre endringer" onClick={updateDocument} iconName="save" />
   {/if}
   <button class="ds-button" type="button" data-variant="secondary" onclick={closeEditor}><span class="material-symbols-outlined">close</span>Avbryt</button>
 </div>

--- a/src/lib/components/Document/DocumentEditor.svelte
+++ b/src/lib/components/Document/DocumentEditor.svelte
@@ -12,6 +12,7 @@
     documentId?: string
     studentId?: string
     groupSystemId?: string
+    documentEdited?: boolean
     currentDocument: DocumentInput
     accessSchools: SchoolInfo[]
     studentDataSharingConsent?: boolean
@@ -20,7 +21,7 @@
     closeEditor: () => void
   }
 
-  let { documentId, studentId, groupSystemId, accessSchools, currentDocument = $bindable(), studentDataSharingConsent, studentAccessPersons, emailAlertAvailable, closeEditor }: EditorProps = $props()
+  let { documentId, studentId, groupSystemId, accessSchools, currentDocument = $bindable(), studentDataSharingConsent, studentAccessPersons, emailAlertAvailable, documentEdited, closeEditor }: EditorProps = $props()
 
   // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
   if (!studentId && !groupSystemId) {
@@ -203,8 +204,7 @@
     <AsyncButton buttonText="Lagre notat" onClick={newDocument} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditor} iconName="save" />
   {/if}
   {#if documentId}
-    <!--TODO sjekk om det er gjort endringer først da... -->
-    <AsyncButton buttonText="Lagre endringer" onClick={updateDocument} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditor} iconName="save" />
+    <AsyncButton disabled={!documentEdited} buttonText="Lagre endringer" onClick={updateDocument} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditor} iconName="save" />
   {/if}
   <button class="ds-button" type="button" data-variant="secondary" onclick={closeEditor}><span class="material-symbols-outlined">close</span>Avbryt</button>
 </div>

--- a/src/lib/components/Document/Message.svelte
+++ b/src/lib/components/Document/Message.svelte
@@ -59,12 +59,12 @@
 
   const newMessage = async (): Promise<AsyncButtonResult> => {
     if (!messageForm) {
-      return { status: 'error', message: "Message form not found" }
+      return { status: "error", message: "Message form not found" }
     }
 
     const formIsValid = messageForm.reportValidity()
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if ("group" in document) {
@@ -78,7 +78,7 @@
         }
       })
 
-      return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
+      return { status: "success", reloadPageData: true, callBack: callBackOnSuccessOrCancel }
     }
 
     if ("student" in document) {
@@ -93,21 +93,21 @@
       })
     }
 
-    return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
+    return { status: "success", reloadPageData: true, callBack: callBackOnSuccessOrCancel }
   }
 
   const updateMessage = async (): Promise<AsyncButtonResult> => {
     if (!messageForm) {
-      return { status: 'error', message: "Message form not found" }
+      return { status: "error", message: "Message form not found" }
     }
 
     const formIsValid = messageForm.reportValidity()
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!message.messageId) {
-      return { status: 'error', message: "messageId is required to update a message" }
+      return { status: "error", message: "messageId is required to update a message" }
     }
 
     if ("group" in document) {
@@ -121,7 +121,7 @@
         }
       })
 
-      return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
+      return { status: "success", reloadPageData: true, callBack: callBackOnSuccessOrCancel }
     }
 
     if ("student" in document) {
@@ -136,7 +136,7 @@
       })
     }
 
-    return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
+    return { status: "success", reloadPageData: true, callBack: callBackOnSuccessOrCancel }
   }
 </script>
 

--- a/src/lib/components/Document/Message.svelte
+++ b/src/lib/components/Document/Message.svelte
@@ -6,7 +6,7 @@
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentAccessPerson } from "$lib/types/app-types"
   import type { DocumentMessage, DocumentMessageInput, GroupDocument, StudentDocument } from "$lib/types/db/shared-types"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
   import EditorInfo from "../EditorInfo.svelte"
   import EmailAlertSelector from "./EmailAlertSelector.svelte"
 
@@ -57,14 +57,14 @@
     editMode = false
   }
 
-  const newMessage = async (): Promise<void> => {
+  const newMessage = async (): Promise<AsyncButtonResult> => {
     if (!messageForm) {
-      throw new Error("Message form not found")
+      return { status: 'error', message: "Message form not found" }
     }
 
     const formIsValid = messageForm.reportValidity()
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if ("group" in document) {
@@ -78,7 +78,7 @@
         }
       })
 
-      return
+      return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
     }
 
     if ("student" in document) {
@@ -92,20 +92,22 @@
         }
       })
     }
+
+    return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
   }
 
-  const updateMessage = async (): Promise<void> => {
+  const updateMessage = async (): Promise<AsyncButtonResult> => {
     if (!messageForm) {
-      throw new Error("Message form not found")
+      return { status: 'error', message: "Message form not found" }
     }
 
     const formIsValid = messageForm.reportValidity()
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!message.messageId) {
-      throw new Error("messageId is required to update a message")
+      return { status: 'error', message: "messageId is required to update a message" }
     }
 
     if ("group" in document) {
@@ -119,7 +121,7 @@
         }
       })
 
-      return
+      return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
     }
 
     if ("student" in document) {
@@ -133,6 +135,8 @@
         }
       })
     }
+
+    return { status: 'success', reloadPageData: true, callBack: callBackOnSuccessOrCancel }
   }
 </script>
 
@@ -191,9 +195,9 @@
 {#if editMode}
   <div class="message-actions">
     {#if !message.messageId}
-      <AsyncButton buttonText="Lagre" onClick={newMessage} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={callBackOnSuccessOrCancel} iconName="save" />
+      <AsyncButton buttonText="Lagre" onClick={newMessage} iconName="save" />
     {:else}
-      <AsyncButton disabled={!messageEdited} buttonText="Lagre endringer" onClick={updateMessage} reloadPageDataOnSuccess={true} callBackAfterReloadPageData={callBackOnSuccessOrCancel} iconName="save" />
+      <AsyncButton disabled={!messageEdited} buttonText="Lagre endringer" onClick={updateMessage} iconName="save" />
     {/if}
     <button class="ds-button" data-variant="secondary" onclick={callBackOnSuccessOrCancel}><span class="material-symbols-outlined">close</span>Avbryt</button>
   </div>

--- a/src/lib/components/ImportantGroupStuff.svelte
+++ b/src/lib/components/ImportantGroupStuff.svelte
@@ -3,7 +3,7 @@
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { ClassGroup, GroupImportantStuff, GroupImportantStuffInput, SchoolInfo } from "$lib/types/db/shared-types"
-  import AsyncButton from "./AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "./AsyncButton.svelte"
   import EditorInfo from "./EditorInfo.svelte"
 
   type GroupImportantStuffProps = {
@@ -31,14 +31,14 @@
     return JSON.stringify(savedEditableGroupImportantStuff) !== JSON.stringify(editableGroupImportantStuff)
   })
 
-  const updateGroupImportantStuff = async (): Promise<void> => {
+  const updateGroupImportantStuff = async (): Promise<AsyncButtonResult> => {
     if (!groupImportantStuffForm) {
-      throw new Error("Important stuff form not found")
+      return { status: 'error', message: "Important stuff form not found" }
     }
 
     const valid = groupImportantStuffForm.reportValidity()
     if (!valid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/classes/${group.systemId as NoSlashString}/importantstuff`, {
@@ -48,6 +48,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
   }
 </script>
 
@@ -85,7 +87,7 @@
 
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={() => updateGroupImportantStuff()} reloadPageDataOnSuccess={true} buttonText="Lagre" iconName="save" callBackAfterReloadPageData={() => { editMode = false }} />
+      <AsyncButton disabled={!hasMadeChanges} onClick={updateGroupImportantStuff} buttonText="Lagre" iconName="save" />
       <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableGroupImportantStuff = $state.snapshot(savedEditableGroupImportantStuff); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}

--- a/src/lib/components/ImportantGroupStuff.svelte
+++ b/src/lib/components/ImportantGroupStuff.svelte
@@ -33,12 +33,12 @@
 
   const updateGroupImportantStuff = async (): Promise<AsyncButtonResult> => {
     if (!groupImportantStuffForm) {
-      return { status: 'error', message: "Important stuff form not found" }
+      return { status: "error", message: "Important stuff form not found" }
     }
 
     const valid = groupImportantStuffForm.reportValidity()
     if (!valid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/classes/${group.systemId as NoSlashString}/importantstuff`, {
@@ -49,7 +49,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        editMode = false
+      }
+    }
   }
 </script>
 

--- a/src/lib/components/SchoolAdministration/ProgramArea.svelte
+++ b/src/lib/components/SchoolAdministration/ProgramArea.svelte
@@ -94,12 +94,12 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
+    return { status: "success", reloadPageData: true, callBack: closeEditMode }
   }
 
   const updateProgramArea = async (): Promise<AsyncButtonResult> => {
     if (!programArea) {
-      return { status: 'error', message: "Kan ikke oppdatere programområde uten å vite hvilket programområde det er snakk om" }
+      return { status: "error", message: "Kan ikke oppdatere programområde uten å vite hvilket programområde det er snakk om" }
     }
 
     const updatedProgramAreaInput = validateAndGetProgramAreaInput()
@@ -112,19 +112,19 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
+    return { status: "success", reloadPageData: true, callBack: closeEditMode }
   }
 
   const deleteProgramArea = async (): Promise<AsyncButtonResult> => {
     if (!programArea) {
-      return { status: 'error', message: "Kan ikke slette programområde uten å vite hvilket programområde det er snakk om" }
+      return { status: "error", message: "Kan ikke slette programområde uten å vite hvilket programområde det er snakk om" }
     }
 
     await apiFetch(`/api/programareas/${programArea._id as NoSlashString}`, {
       method: "DELETE"
     })
 
-    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
+    return { status: "success", reloadPageData: true, callBack: closeEditMode }
   }
 
   const closeEditMode = (): void => {

--- a/src/lib/components/SchoolAdministration/ProgramArea.svelte
+++ b/src/lib/components/SchoolAdministration/ProgramArea.svelte
@@ -6,7 +6,7 @@
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { AccessControlClass } from "$lib/types/app-types"
   import type { ProgramArea, ProgramAreaInput } from "$lib/types/db/shared-types"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
 
   type ProgramAreaProps = {
     programArea?: ProgramArea | undefined
@@ -83,7 +83,7 @@
     }
   }
 
-  const createProgramArea = async (): Promise<void> => {
+  const createProgramArea = async (): Promise<AsyncButtonResult> => {
     const newProgramAreaInput = validateAndGetProgramAreaInput()
 
     await apiFetch(`/api/programareas`, {
@@ -93,11 +93,13 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
   }
 
-  const updateProgramArea = async (): Promise<void> => {
+  const updateProgramArea = async (): Promise<AsyncButtonResult> => {
     if (!programArea) {
-      throw new Error("Kan ikke oppdatere programområde uten å vite hvilket programområde det er snakk om")
+      return { status: 'error', message: "Kan ikke oppdatere programområde uten å vite hvilket programområde det er snakk om" }
     }
 
     const updatedProgramAreaInput = validateAndGetProgramAreaInput()
@@ -109,16 +111,20 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
   }
 
-  const deleteProgramArea = async (): Promise<void> => {
+  const deleteProgramArea = async (): Promise<AsyncButtonResult> => {
     if (!programArea) {
-      throw new Error("Kan ikke slette programområde uten å vite hvilket programområde det er snakk om")
+      return { status: 'error', message: "Kan ikke slette programområde uten å vite hvilket programområde det er snakk om" }
     }
 
     await apiFetch(`/api/programareas/${programArea._id as NoSlashString}`, {
       method: "DELETE"
     })
+
+    return { status: 'success', reloadPageData: true, callBack: closeEditMode }
   }
 
   const closeEditMode = (): void => {
@@ -188,10 +194,10 @@
 
     <div class="program-area-actions">
       {#if programArea}
-        <AsyncButton disabled={!programAreaEdited && nonExistingProgramAreas.length === 0} onClick={updateProgramArea} buttonText="Lagre endringer" iconName="save" reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditMode} />
-        <AsyncButton onClick={deleteProgramArea} buttonText="Slett programområde" iconName="delete" color="danger" reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditMode} />
+        <AsyncButton disabled={!programAreaEdited && nonExistingProgramAreas.length === 0} onClick={updateProgramArea} buttonText="Lagre endringer" iconName="save" />
+        <AsyncButton onClick={deleteProgramArea} buttonText="Slett programområde" iconName="delete" color="danger" />
       {:else}
-        <AsyncButton onClick={createProgramArea} buttonText="Opprett programområde" iconName="save" reloadPageDataOnSuccess={true} callBackAfterReloadPageData={closeEditMode} />
+        <AsyncButton onClick={createProgramArea} buttonText="Opprett programområde" iconName="save" />
       {/if}
       <button class="ds-button" data-variant="secondary" onclick={closeEditMode}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>

--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -5,7 +5,7 @@
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { FrontendStudent, StudentUnavailableSchoolDocuments } from "$lib/types/app-types"
   import type { StudentDataSharingConsent, StudentDataSharingConsentInput } from "$lib/types/db/shared-types"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
   import EditorInfo from "../EditorInfo.svelte"
 
   type DataSharingConsentProps = {
@@ -35,13 +35,13 @@
     return JSON.stringify(savedEditableSharingConsent) !== JSON.stringify(editableSharingConsent)
   })
 
-  const updateStudentDataSharingConsent = async (): Promise<void> => {
+  const updateStudentDataSharingConsent = async (): Promise<AsyncButtonResult> => {
     if (!consentForm) {
-      throw new Error("Consent form not found")
+      return { status: 'error', message: "Consent form not found" }
     }
     const valid = consentForm.reportValidity()
     if (!valid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/consent`, {
@@ -51,6 +51,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
   }
 </script>
 
@@ -104,7 +106,7 @@
   </div>
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={() => updateStudentDataSharingConsent()} reloadPageDataOnSuccess={true} buttonText="Lagre" iconName="save" callBackAfterReloadPageData={() => { editMode = false }} />
+      <AsyncButton disabled={!hasMadeChanges} onClick={updateStudentDataSharingConsent} buttonText="Lagre" iconName="save" />
       <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableSharingConsent = $state.snapshot(savedEditableSharingConsent); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}

--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -37,11 +37,11 @@
 
   const updateStudentDataSharingConsent = async (): Promise<AsyncButtonResult> => {
     if (!consentForm) {
-      return { status: 'error', message: "Consent form not found" }
+      return { status: "error", message: "Consent form not found" }
     }
     const valid = consentForm.reportValidity()
     if (!valid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/consent`, {
@@ -52,7 +52,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        editMode = false
+      }
+    }
   }
 </script>
 

--- a/src/lib/components/StudentBoxes/ImportantStuff.svelte
+++ b/src/lib/components/StudentBoxes/ImportantStuff.svelte
@@ -47,11 +47,11 @@
 
   const updateStudentImportantStuff = async (): Promise<AsyncButtonResult> => {
     if (!importantStuffForm) {
-      return { status: 'error', message: "Important stuff form not found" }
+      return { status: "error", message: "Important stuff form not found" }
     }
     const valid = importantStuffForm.reportValidity()
     if (!valid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/importantstuff`, {
@@ -62,7 +62,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        editMode = false
+      }
+    }
   }
 </script>
 

--- a/src/lib/components/StudentBoxes/ImportantStuff.svelte
+++ b/src/lib/components/StudentBoxes/ImportantStuff.svelte
@@ -5,7 +5,7 @@
   import type { FrontendStudent } from "$lib/types/app-types"
   import type { SchoolInfo, StudentCheckBox, StudentImportantStuff, StudentImportantStuffInput } from "$lib/types/db/shared-types"
   import { STUDENT_CHECKBOX_DISPLAY_NAMES } from "$lib/utils/student-checkbox-constants"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
   import EditorInfo from "../EditorInfo.svelte"
 
   type ImportantStuffProps = {
@@ -45,13 +45,13 @@
       .map((checkbox) => checkbox.value)
   }
 
-  const updateStudentImportantStuff = async (): Promise<void> => {
+  const updateStudentImportantStuff = async (): Promise<AsyncButtonResult> => {
     if (!importantStuffForm) {
-      throw new Error("Important stuff form not found")
+      return { status: 'error', message: "Important stuff form not found" }
     }
     const valid = importantStuffForm.reportValidity()
     if (!valid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/importantstuff`, {
@@ -61,6 +61,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { editMode = false } }
   }
 </script>
 
@@ -148,7 +150,7 @@
 
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={() => updateStudentImportantStuff()} reloadPageDataOnSuccess={true} buttonText="Lagre" iconName="save" callBackAfterReloadPageData={() => { editMode = false }} />
+      <AsyncButton disabled={!hasMadeChanges} onClick={updateStudentImportantStuff} buttonText="Lagre" iconName="save" />
       <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableImportantStuff = $state.snapshot(savedEditableImportantStuff); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}

--- a/src/lib/components/StudentCheckBox.svelte
+++ b/src/lib/components/StudentCheckBox.svelte
@@ -5,7 +5,7 @@
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentCheckBox, StudentCheckBoxInput } from "$lib/types/db/shared-types"
   import { prettifyDateTime } from "$lib/utils/dates"
-  import AsyncButton from "./AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "./AsyncButton.svelte"
 
   type StudentCheckBoxProps = {
     checkBox: StudentCheckBox
@@ -37,13 +37,13 @@
     }
   }
 
-  const createStudentCheckBox = async (): Promise<void> => {
+  const createStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!studentCheckBoxFormNew) {
-      throw new Error("Student new checkbox form not found")
+      return { status: 'error', message: "Student new checkbox form not found" }
     }
 
     if (!studentCheckBoxFormNew.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch("/api/studentcheckboxes", {
@@ -53,42 +53,46 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
   }
 
-  const deleteStudentCheckBox = async (): Promise<void> => {
+  const deleteStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!checkBox._id) {
-      throw new Error("Mangler id for å kunne slette")
+      return { status: 'error', message: "Mangler id for å kunne slette" }
     }
 
     const confirmation = confirm("Er du sikker på at du vil slette denne sjekkboksen? Den vil bli fjernet fra alle elever, og må legges til på nytt på hver elev dersom den skal legges til på nytt.")
     if (!confirmation) {
-      return
+      return { status: 'cancelled' }
     }
 
     await apiFetch(`/api/studentcheckboxes/${checkBox._id as NoSlashString}`, {
       method: "DELETE"
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
   }
 
-  const updateStudentCheckBox = async (): Promise<void> => {
+  const updateStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!checkBox._id) {
-      throw new Error("Mangler id for å kunne oppdatere")
+      return { status: 'error', message: "Mangler id for å kunne oppdatere" }
     }
 
     if (!studentCheckBoxFormEditName) {
-      throw new Error("Student edit checkbox name form not found")
+      return { status: 'error', message: "Student edit checkbox name form not found" }
     }
 
     if (!studentCheckBoxFormEditName.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!studentCheckBoxFormEditSort) {
-      throw new Error("Student edit checkbox sort form not found")
+      return { status: 'error', message: "Student edit checkbox sort form not found" }
     }
 
     if (!studentCheckBoxFormEditSort.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/studentcheckboxes/${checkBox._id as NoSlashString}`, {
@@ -98,14 +102,8 @@
         "Content-Type": "application/json"
       }
     })
-  }
 
-  const callBackAfterReloadPageData = (): void => {
-    if (callBackOnCreate) {
-      callBackOnCreate()
-    }
-
-    editMode = false
+    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
   }
 </script>
 
@@ -142,7 +140,7 @@
       </ds-field>
 
       <div class="student_check_box_edit_actions">
-        <AsyncButton onClick={createStudentCheckBox} buttonText="Opprett" iconName="add" reloadPageDataOnSuccess={true} {callBackAfterReloadPageData} />
+        <AsyncButton onClick={createStudentCheckBox} buttonText="Opprett" iconName="add" />
         <button class="ds-button" type="button" data-variant="secondary" onclick={cancelStudentCheckBox}>Avbryt</button>
       </div>
     </div>
@@ -193,9 +191,9 @@
     <div class="student_check_box_edit_actions">
       {#if !editMode}
         <button class="ds-button" type="button" data-size="sm" onclick={() => editMode = true}><span class="material-symbols-outlined">edit</span>Rediger</button>
-        <AsyncButton onClick={deleteStudentCheckBox} buttonText="Slett" iconName="delete" dataSize="sm" color="danger" reloadPageDataOnSuccess={true} {callBackAfterReloadPageData} />
+        <AsyncButton onClick={deleteStudentCheckBox} buttonText="Slett" iconName="delete" dataSize="sm" color="danger" />
       {:else}
-        <AsyncButton onClick={updateStudentCheckBox} buttonText="Lagre" iconName="save" dataSize="sm" reloadPageDataOnSuccess={true} {callBackAfterReloadPageData} />
+        <AsyncButton onClick={updateStudentCheckBox} buttonText="Lagre" iconName="save" dataSize="sm" />
         <button class="ds-button" type="button" data-size="sm" data-variant="secondary" onclick={cancelStudentCheckBox}>Avbryt</button>
       {/if}
     </div>

--- a/src/lib/components/StudentCheckBox.svelte
+++ b/src/lib/components/StudentCheckBox.svelte
@@ -39,11 +39,11 @@
 
   const createStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!studentCheckBoxFormNew) {
-      return { status: 'error', message: "Student new checkbox form not found" }
+      return { status: "error", message: "Student new checkbox form not found" }
     }
 
     if (!studentCheckBoxFormNew.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch("/api/studentcheckboxes", {
@@ -54,45 +54,59 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        callBackOnCreate?.()
+        editMode = false
+      }
+    }
   }
 
   const deleteStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!checkBox._id) {
-      return { status: 'error', message: "Mangler id for å kunne slette" }
+      return { status: "error", message: "Mangler id for å kunne slette" }
     }
 
     const confirmation = confirm("Er du sikker på at du vil slette denne sjekkboksen? Den vil bli fjernet fra alle elever, og må legges til på nytt på hver elev dersom den skal legges til på nytt.")
     if (!confirmation) {
-      return { status: 'cancelled' }
+      return { status: "cancelled" }
     }
 
     await apiFetch(`/api/studentcheckboxes/${checkBox._id as NoSlashString}`, {
       method: "DELETE"
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        callBackOnCreate?.()
+        editMode = false
+      }
+    }
   }
 
   const updateStudentCheckBox = async (): Promise<AsyncButtonResult> => {
     if (!checkBox._id) {
-      return { status: 'error', message: "Mangler id for å kunne oppdatere" }
+      return { status: "error", message: "Mangler id for å kunne oppdatere" }
     }
 
     if (!studentCheckBoxFormEditName) {
-      return { status: 'error', message: "Student edit checkbox name form not found" }
+      return { status: "error", message: "Student edit checkbox name form not found" }
     }
 
     if (!studentCheckBoxFormEditName.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!studentCheckBoxFormEditSort) {
-      return { status: 'error', message: "Student edit checkbox sort form not found" }
+      return { status: "error", message: "Student edit checkbox sort form not found" }
     }
 
     if (!studentCheckBoxFormEditSort.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/studentcheckboxes/${checkBox._id as NoSlashString}`, {
@@ -103,7 +117,14 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { callBackOnCreate?.(); editMode = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        callBackOnCreate?.()
+        editMode = false
+      }
+    }
   }
 </script>
 

--- a/src/lib/components/TemplateEditor/TemplateEditor.svelte
+++ b/src/lib/components/TemplateEditor/TemplateEditor.svelte
@@ -4,7 +4,7 @@
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { DocumentContentItem, DocumentContentTemplate } from "$lib/types/db/shared-types"
-  import AsyncButton from "../AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
   import DocumentContentItemComponent from "../Document/DocumentContentItem.svelte"
   import TemplateEditorItem from "./TemplateEditorItem.svelte"
   import { templateEditorContentItemIcons, templateEditorContentItemNames } from "./template-editor-constants"
@@ -113,10 +113,11 @@
     return templateForm.reportValidity()
   }
 
-  const newTemplate = async (): Promise<void> => {
+  const newTemplate = async (): Promise<AsyncButtonResult> => {
     const formIsValid = validateTemplate()
+    
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     const { templateId } = await apiFetch(`/api/templates`, {
@@ -131,12 +132,15 @@
 
     // redirect and reload page data
     await goto(`/system/templates/${templateId}`, { invalidateAll: true })
+
+    return { status: 'success' }
   }
 
-  const updateTemplate = async (): Promise<void> => {
+  const updateTemplate = async (): Promise<AsyncButtonResult> => {
     const formIsValid = validateTemplate()
+    
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
@@ -147,13 +151,13 @@
       }
     })
 
-    previewMode = true
+    return { status: 'success', reloadPageData: true, callBack: () => { previewMode = true } }
   }
 
-  const deleteTemplate = async (): Promise<void> => {
+  const deleteTemplate = async (): Promise<AsyncButtonResult> => {
     const confirmDelete = confirm("Er du heeeelt sikker på du vil slette denne malen da? Den vil ikke kunne brukes lenger. Dokumentene som er laget med malen vil ikke bli slettet.")
     if (!confirmDelete) {
-      return
+      return { status: 'cancelled' }
     }
 
     await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
@@ -162,6 +166,8 @@
 
     // redirect and reload page data
     await goto(`/system/templates`, { invalidateAll: true })
+
+    return { status: 'success' }
   }
 </script>
 
@@ -234,7 +240,7 @@
     {#if !editableTemplate._id}
       <AsyncButton buttonText="Lagre mal" onClick={newTemplate} iconName="save" />
     {:else}
-      <AsyncButton disabled={JSON.stringify(editableTemplate) === JSON.stringify(template)} buttonText="Lagre endringer" onClick={updateTemplate} reloadPageDataOnSuccess={true} iconName="save" />
+      <AsyncButton disabled={JSON.stringify(editableTemplate) === JSON.stringify(template)} buttonText="Lagre endringer" onClick={updateTemplate} iconName="save" />
     {/if}
     <button class="ds-button" data-variant="secondary" type="button" onclick={() => previewMode = true}><span class="material-symbols-outlined">visibility</span>Forhåndsvis mal</button>
   {/if}

--- a/src/lib/components/TemplateEditor/TemplateEditor.svelte
+++ b/src/lib/components/TemplateEditor/TemplateEditor.svelte
@@ -115,9 +115,9 @@
 
   const newTemplate = async (): Promise<AsyncButtonResult> => {
     const formIsValid = validateTemplate()
-    
+
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     const { templateId } = await apiFetch(`/api/templates`, {
@@ -133,14 +133,14 @@
     // redirect and reload page data
     await goto(`/system/templates/${templateId}`, { invalidateAll: true })
 
-    return { status: 'success' }
+    return { status: "success" }
   }
 
   const updateTemplate = async (): Promise<AsyncButtonResult> => {
     const formIsValid = validateTemplate()
-    
+
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
@@ -151,13 +151,19 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { previewMode = true } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        previewMode = true
+      }
+    }
   }
 
   const deleteTemplate = async (): Promise<AsyncButtonResult> => {
     const confirmDelete = confirm("Er du heeeelt sikker på du vil slette denne malen da? Den vil ikke kunne brukes lenger. Dokumentene som er laget med malen vil ikke bli slettet.")
     if (!confirmDelete) {
-      return { status: 'cancelled' }
+      return { status: "cancelled" }
     }
 
     await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
@@ -167,7 +173,7 @@
     // redirect and reload page data
     await goto(`/system/templates`, { invalidateAll: true })
 
-    return { status: 'success' }
+    return { status: "success" }
   }
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { env } from "$env/dynamic/public"
   import favicon16 from "$lib/assets/favicon-32x32.png"
   import favicon32 from "$lib/assets/favicon-32x32.png"
   import "@digdir/designsystemet-web" // For ds to work

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import PageHeader from "$lib/components/PageHeader.svelte"
   import ProgramAreaComponent from "$lib/components/SchoolAdministration/ProgramArea.svelte"
   import SuggestionSelect from "$lib/components/SchoolAdministration/SuggestionSelect.svelte"
@@ -365,7 +365,7 @@
     newManualAccessControl.entraUserId = ""
   }
 
-  const addManualAccessEntry = async (newManualAccessControl: NewManualAccessControl): Promise<void> => {
+  const addManualAccessEntry = async (newManualAccessControl: NewManualAccessControl): Promise<AsyncButtonResult> => {
     if (!newManualAccessControl.form) {
       throw new Error("Form reference is missing")
     }
@@ -387,7 +387,7 @@
     switch (newManualAccessControl.type) {
       case "MANUELL-PROGRAMOMRÅDE-TILGANG": {
         if (!newManualAccessControl.programAreaId) {
-          throw new Error("Programområde must be selected")
+          return { status: 'error', message: "Programområde ID must be selected" }
         }
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, _id: newManualAccessControl.programAreaId }
         break
@@ -395,7 +395,7 @@
 
       case "MANUELL-KLASSE-TILGANG": {
         if (!newManualAccessControl.classId) {
-          throw new Error("Class ID must be selected")
+          return { status: 'error', message: "Class ID must be selected" }
         }
 
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, systemId: newManualAccessControl.classId }
@@ -404,7 +404,7 @@
 
       case "MANUELL-ELEV-TILGANG": {
         if (!newManualAccessControl.studentId) {
-          throw new Error("Student ID must be selected")
+          return { status: 'error', message: "Student ID must be selected" }
         }
 
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, _id: newManualAccessControl.studentId }
@@ -417,7 +417,7 @@
         break
 
       default:
-        throw new Error(`Invalid access entry type: ${newManualAccessControl.type}`)
+        return { status: 'error', message: `Invalid access entry type: ${newManualAccessControl.type}` }
     }
 
     await apiFetch(`/api/access/${newManualAccessControl.entraUserId as NoSlashString}/add`, {
@@ -427,9 +427,11 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => closeManualAccessControl(newManualAccessControl) }
   }
 
-  const removeManualAccessEntry = async (entraUserId: string, accessEntry: ManualAccessEntryInput): Promise<void> => {
+  const removeManualAccessEntry = async (entraUserId: string, accessEntry: ManualAccessEntryInput): Promise<AsyncButtonResult> => {
     await apiFetch(`/api/access/${entraUserId as NoSlashString}/remove`, {
       method: "POST",
       body: accessEntry,
@@ -437,6 +439,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true }
   }
 
   /* --- PROGRAM AREAS --- */
@@ -450,17 +454,17 @@
   let newManualStudentHasBlockedAddress = $state(false)
   let newManualStudentFormOpen = $state(false)
 
-  const addNewManualStudent = async (): Promise<void> => {
+  const addNewManualStudent = async (): Promise<AsyncButtonResult> => {
     if (!addManualStudentForm?.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!newManualStudentFnr) {
-      throw new Error("Fødselsnummer må være fylt ut")
+      return { status: 'error', message: "Fødselsnummer må være fylt ut" }
     }
 
     if (!newManualStudentName) {
-      throw new Error("Navn må være fylt ut")
+      return { status: 'error', message: "Navn må være fylt ut" }
     }
 
     const newManualStudentInput: NewManualStudentInput = {
@@ -477,6 +481,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: closeNewManualStudentForm }
   }
 
   let canManageManualStudents = $derived.by(() => {
@@ -539,7 +545,7 @@
         {/if}
 
         <div class="new-manual-access-actions">
-          <AsyncButton onClick={() => addManualAccessEntry(newManualAccessControl)} reloadPageDataOnSuccess={true} buttonText="Legg til tilgang" iconName="add" callBackAfterReloadPageData={() => closeManualAccessControl(newManualAccessControl)} />
+          <AsyncButton onClick={() => addManualAccessEntry(newManualAccessControl)} buttonText="Legg til tilgang" iconName="add" />
 
           <button class="ds-button" type="button" data-variant="secondary" onclick={() => closeManualAccessControl(newManualAccessControl)}>
             <span class="material-symbols-outlined">close</span>Lukk
@@ -600,7 +606,7 @@
                     <td>{programAreaAccess.programAreaName}</td>
                     <td>{programAreaAccess.entraUser.name} ({programAreaAccess.entraUser.companyName})</td>
                     <td>
-                      <AsyncButton onClick={() => removeManualAccessEntry(programAreaAccess.entraUser.id, programAreaAccess.accessEntry)} reloadPageDataOnSuccess={true} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                      <AsyncButton onClick={() => removeManualAccessEntry(programAreaAccess.entraUser.id, programAreaAccess.accessEntry)} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
                     </td>
                   </tr>
                 {/each}
@@ -633,7 +639,7 @@
                     <td>{classAccess.className}</td>
                     <td>{classAccess.entraUser.name} ({classAccess.entraUser.companyName})</td>
                     <td>
-                      <AsyncButton onClick={() => removeManualAccessEntry(classAccess.entraUser.id, classAccess.accessEntry)} reloadPageDataOnSuccess={true} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                      <AsyncButton onClick={() => removeManualAccessEntry(classAccess.entraUser.id, classAccess.accessEntry)} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
                     </td>
                   </tr>
                 {/each}
@@ -667,7 +673,7 @@
                     <td>{studentAccess.student.name} ({studentAccess.student.feideName})</td>
                     <td>{studentAccess.entraUser.name} ({studentAccess.entraUser.companyName})</td>
                     <td>
-                      <AsyncButton onClick={() => removeManualAccessEntry(studentAccess.entraUser.id, studentAccess.accessEntry)} reloadPageDataOnSuccess={true} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                      <AsyncButton onClick={() => removeManualAccessEntry(studentAccess.entraUser.id, studentAccess.accessEntry)} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
                     </td>
                   </tr>
                 {/each}
@@ -697,7 +703,7 @@
                   <tr>
                     <td>{allStudentsAccess.entraUser.name} ({allStudentsAccess.entraUser.companyName})</td>
                     <td>
-                      <AsyncButton onClick={() => removeManualAccessEntry(allStudentsAccess.entraUser.id, allStudentsAccess.accessEntry)} reloadPageDataOnSuccess={true} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                      <AsyncButton onClick={() => removeManualAccessEntry(allStudentsAccess.entraUser.id, allStudentsAccess.accessEntry)} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
                     </td>
                   </tr>
                 {/each}
@@ -729,7 +735,7 @@
                       {manualStudentsAccess.entraUser.name} ({manualStudentsAccess.entraUser.companyName})
                     </td>
                     <td>
-                      <AsyncButton onClick={() => removeManualAccessEntry(manualStudentsAccess.entraUser.id, manualStudentsAccess.accessEntry)} reloadPageDataOnSuccess={true} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                      <AsyncButton onClick={() => removeManualAccessEntry(manualStudentsAccess.entraUser.id, manualStudentsAccess.accessEntry)} buttonText="Fjern tilgang" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
                     </td>
                   </tr>
                 {/each}
@@ -809,7 +815,7 @@
             </form>
   
             <div class="manual-student-actions">
-              <AsyncButton onClick={addNewManualStudent} reloadPageDataOnSuccess={true} buttonText="Legg til ny manuell elev" iconName="add" callBackAfterReloadPageData={closeNewManualStudentForm} />
+              <AsyncButton onClick={addNewManualStudent} buttonText="Legg til ny manuell elev" iconName="add" />
               <button class="ds-button" type="button" data-variant="secondary" onclick={closeNewManualStudentForm}><span class="material-symbols-outlined">close</span>Avbryt</button>
             </div>
           </div>

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -367,19 +367,19 @@
 
   const addManualAccessEntry = async (newManualAccessControl: NewManualAccessControl): Promise<AsyncButtonResult> => {
     if (!newManualAccessControl.form) {
-      throw new Error("Form reference is missing")
+      return { status: 'error', message: "Form not found for new manual access control" }
     }
 
     if (!newManualAccessControl.form.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!newManualAccessControl.type) {
-      throw new Error("Access type must be selected")
+      return { status: 'error', message: "Access type must be selected" }
     }
 
     if (!newManualAccessControl.entraUserId) {
-      throw new Error("Entra user ID must be selected")
+      return { status: 'error', message: "Entra user ID must be selected" }
     }
 
     let accessEntryToAdd: ManualAccessEntryInput

--- a/src/routes/schooladministration/[schoolnumber]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/+page.svelte
@@ -367,19 +367,19 @@
 
   const addManualAccessEntry = async (newManualAccessControl: NewManualAccessControl): Promise<AsyncButtonResult> => {
     if (!newManualAccessControl.form) {
-      return { status: 'error', message: "Form not found for new manual access control" }
+      return { status: "error", message: "Form not found for new manual access control" }
     }
 
     if (!newManualAccessControl.form.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!newManualAccessControl.type) {
-      return { status: 'error', message: "Access type must be selected" }
+      return { status: "error", message: "Access type must be selected" }
     }
 
     if (!newManualAccessControl.entraUserId) {
-      return { status: 'error', message: "Entra user ID must be selected" }
+      return { status: "error", message: "Entra user ID must be selected" }
     }
 
     let accessEntryToAdd: ManualAccessEntryInput
@@ -387,7 +387,7 @@
     switch (newManualAccessControl.type) {
       case "MANUELL-PROGRAMOMRÅDE-TILGANG": {
         if (!newManualAccessControl.programAreaId) {
-          return { status: 'error', message: "Programområde ID must be selected" }
+          return { status: "error", message: "Programområde ID must be selected" }
         }
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, _id: newManualAccessControl.programAreaId }
         break
@@ -395,7 +395,7 @@
 
       case "MANUELL-KLASSE-TILGANG": {
         if (!newManualAccessControl.classId) {
-          return { status: 'error', message: "Class ID must be selected" }
+          return { status: "error", message: "Class ID must be selected" }
         }
 
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, systemId: newManualAccessControl.classId }
@@ -404,7 +404,7 @@
 
       case "MANUELL-ELEV-TILGANG": {
         if (!newManualAccessControl.studentId) {
-          return { status: 'error', message: "Student ID must be selected" }
+          return { status: "error", message: "Student ID must be selected" }
         }
 
         accessEntryToAdd = { type: newManualAccessControl.type, schoolNumber: currentSchool.schoolNumber, _id: newManualAccessControl.studentId }
@@ -417,7 +417,7 @@
         break
 
       default:
-        return { status: 'error', message: `Invalid access entry type: ${newManualAccessControl.type}` }
+        return { status: "error", message: `Invalid access entry type: ${newManualAccessControl.type}` }
     }
 
     await apiFetch(`/api/access/${newManualAccessControl.entraUserId as NoSlashString}/add`, {
@@ -428,7 +428,7 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => closeManualAccessControl(newManualAccessControl) }
+    return { status: "success", reloadPageData: true, callBack: () => closeManualAccessControl(newManualAccessControl) }
   }
 
   const removeManualAccessEntry = async (entraUserId: string, accessEntry: ManualAccessEntryInput): Promise<AsyncButtonResult> => {
@@ -440,7 +440,7 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true }
+    return { status: "success", reloadPageData: true }
   }
 
   /* --- PROGRAM AREAS --- */
@@ -456,15 +456,15 @@
 
   const addNewManualStudent = async (): Promise<AsyncButtonResult> => {
     if (!addManualStudentForm?.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!newManualStudentFnr) {
-      return { status: 'error', message: "Fødselsnummer må være fylt ut" }
+      return { status: "error", message: "Fødselsnummer må være fylt ut" }
     }
 
     if (!newManualStudentName) {
-      return { status: 'error', message: "Navn må være fylt ut" }
+      return { status: "error", message: "Navn må være fylt ut" }
     }
 
     const newManualStudentInput: NewManualStudentInput = {
@@ -482,7 +482,7 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: closeNewManualStudentForm }
+    return { status: "success", reloadPageData: true, callBack: closeNewManualStudentForm }
   }
 
   let canManageManualStudents = $derived.by(() => {

--- a/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import PageHeader from "$lib/components/PageHeader.svelte"
   import { nameValidation, ssnValidation } from "$lib/data-validation/manual-student-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
@@ -30,17 +30,17 @@
   let updateManualStudentName: string = $derived.by(() => data.manualStudent.name)
   let updateManualStudentHasBlockedAddress: boolean = $derived.by(() => data.manualStudent.hasBlockedAddress ?? false)
 
-  const updateManualStudent = async (): Promise<void> => {
+  const updateManualStudent = async (): Promise<AsyncButtonResult> => {
     if (!updateManualStudentForm?.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!updateManualStudentFnr) {
-      throw new Error("Fødselsnummer må være fylt ut")
+      return { status: 'error', message: "Fødselsnummer må være fylt ut" }
     }
 
     if (!updateManualStudentName) {
-      throw new Error("Navn må være fylt ut")
+      return { status: 'error', message: "Navn må være fylt ut" }
     }
 
     const updateManualStudentInput: UpdateManualStudentInput = {
@@ -59,7 +59,7 @@
       }
     })
 
-    updateManualStudentEdit = false
+    return { status: 'success', reloadPageData: true, callBack: () => { updateManualStudentEdit = false } }
   }
 
   const abortUpdateManualStudent = () => {
@@ -135,7 +135,7 @@
       </form>
 
       <div class="manual-student-save-actions">
-        <AsyncButton onClick={updateManualStudent} buttonText="Lagre" iconName="save" reloadPageDataOnSuccess={true} disabled={isDisabled()} />
+        <AsyncButton onClick={updateManualStudent} buttonText="Lagre" iconName="save" disabled={isDisabled()} />
         <button class="ds-button" type="button" data-variant="secondary" onclick={abortUpdateManualStudent}><span class="material-symbols-outlined">close</span>Avbryt</button>
       </div>
     </div>

--- a/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
@@ -32,15 +32,15 @@
 
   const updateManualStudent = async (): Promise<AsyncButtonResult> => {
     if (!updateManualStudentForm?.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!updateManualStudentFnr) {
-      return { status: 'error', message: "Fødselsnummer må være fylt ut" }
+      return { status: "error", message: "Fødselsnummer må være fylt ut" }
     }
 
     if (!updateManualStudentName) {
-      return { status: 'error', message: "Navn må være fylt ut" }
+      return { status: "error", message: "Navn må være fylt ut" }
     }
 
     const updateManualStudentInput: UpdateManualStudentInput = {
@@ -59,7 +59,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { updateManualStudentEdit = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        updateManualStudentEdit = false
+      }
+    }
   }
 
   const abortUpdateManualStudent = () => {

--- a/src/routes/system/audit/+page.svelte
+++ b/src/routes/system/audit/+page.svelte
@@ -70,7 +70,7 @@
     auditEntries = queriedAuditEntries.entries
     auditSearchError = queriedAuditEntries.errorMessage
 
-    return { status: 'success' }
+    return { status: "success" }
   }
 
   const getStringifiedMetadata = (metaData: AuditEntry["metaData"]): string => {

--- a/src/routes/system/audit/+page.svelte
+++ b/src/routes/system/audit/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import type { AuditEntry, AuditSearchQueryResult, AuditSearchTerms, ConstantDisplayNameEntry } from "$lib/types/db/shared-types"
   import { AUDIT_ENTRY_ACTION_DISPLAY_NAMES, AUDIT_ENTRY_RESOURCE_DISPLAY_NAMES } from "$lib/utils/audit-constants"
   import { getDateDaysBack, getDateValue, prettifyDateTime } from "$lib/utils/dates"
@@ -58,7 +58,7 @@
     }
   })
 
-  const handleSearch = async (): Promise<void> => {
+  const handleSearch = async (): Promise<AsyncButtonResult> => {
     const queriedAuditEntries: AuditSearchQueryResult = await apiFetch("/api/audit/query", {
       headers: {
         "Content-Type": "application/json"
@@ -69,6 +69,8 @@
 
     auditEntries = queriedAuditEntries.entries
     auditSearchError = queriedAuditEntries.errorMessage
+
+    return { status: 'success' }
   }
 
   const getStringifiedMetadata = (metaData: AuditEntry["metaData"]): string => {

--- a/src/routes/system/schools/+page.svelte
+++ b/src/routes/system/schools/+page.svelte
@@ -31,12 +31,12 @@
 
   const newSchool = async (): Promise<AsyncButtonResult> => {
     if (!newSchoolForm) {
-      return { status: 'error', message: "New school form not found" }
+      return { status: "error", message: "New school form not found" }
     }
 
     const formIsValid = newSchoolForm.reportValidity()
     if (!formIsValid) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch("/api/schools", {
@@ -47,7 +47,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { newSchoolOpen = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        newSchoolOpen = false
+      }
+    }
   }
 </script>
 

--- a/src/routes/system/schools/+page.svelte
+++ b/src/routes/system/schools/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import PageHeader from "$lib/components/PageHeader.svelte"
   import { schoolNameValidation, schoolNumberValidation } from "$lib/data-validation/school-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
@@ -29,14 +29,14 @@
     modified: mockEditor
   }
 
-  const newSchool = async (): Promise<void> => {
+  const newSchool = async (): Promise<AsyncButtonResult> => {
     if (!newSchoolForm) {
-      throw new Error("New school form not found")
+      return { status: 'error', message: "New school form not found" }
     }
 
     const formIsValid = newSchoolForm.reportValidity()
     if (!formIsValid) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     await apiFetch("/api/schools", {
@@ -46,6 +46,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: () => { newSchoolOpen = false } }
   }
 </script>
 
@@ -84,7 +86,7 @@
       </form>
 
       <div class="new-school-actions">
-        <AsyncButton onClick={newSchool} buttonText="Legg til ny skole" reloadPageDataOnSuccess={true} iconName="add" callBackAfterReloadPageData={() => newSchoolOpen = false} />
+        <AsyncButton onClick={newSchool} buttonText="Legg til ny skole" iconName="add" />
         <button class="ds-button" type="button" data-variant="secondary" onclick={() => newSchoolOpen = false}>
           <span class="material-symbols-outlined">close</span>
           Avbryt

--- a/src/routes/system/schools/[schoolnumber]/+page.svelte
+++ b/src/routes/system/schools/[schoolnumber]/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from "$app/navigation"
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
-  import AsyncButton from "$lib/components/AsyncButton.svelte"
+  import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
   import PageHeader from "$lib/components/PageHeader.svelte"
   import SuggestionSelect from "$lib/components/SchoolAdministration/SuggestionSelect.svelte"
   import { schoolNameValidation } from "$lib/data-validation/school-validation"
@@ -44,11 +44,11 @@
 
   let addSchoolLeaderOpen = $state(false)
 
-  const deleteManualSchool = async (): Promise<void> => {
+  const deleteManualSchool = async (): Promise<AsyncButtonResult> => {
     const confirmDelete = confirm(`Er du sikker på at du vil slette skolen "${currentSchool.name}"? Dette kan ikke angres.`)
 
     if (!confirmDelete) {
-      return
+      return { status: 'cancelled' }
     }
 
     await apiFetch(`/api/schools/${currentSchool.schoolNumber as NoSlashString}`, {
@@ -57,6 +57,8 @@
 
     // redirect to schools admin page and reload dependent data
     await goto("/system/schools", { invalidateAll: true })
+
+    return { status: 'success' }
   }
 
   let selectedEntraUserId = $state("")
@@ -65,7 +67,7 @@
   let updateSchoolForm: HTMLFormElement | undefined = $state()
   let updateSchoolName: string = $derived.by(() => currentSchool.name)
 
-  const updateSchool = async (): Promise<void> => {
+  const updateSchool = async (): Promise<AsyncButtonResult> => {
     if (!updateSchoolForm?.reportValidity()) {
       throw new Error(INVALID_FORM_MESSAGE)
     }
@@ -87,7 +89,7 @@
       }
     })
 
-    updateSchoolEdit = false
+    return { status: 'success', reloadPageData: true, callBack: () => { updateSchoolEdit = false } }
   }
 
   const abortUpdateSchool = () => {
@@ -104,7 +106,7 @@
     selectedEntraUserId = ""
   }
 
-  const addSchoolLeaderAccess = async (): Promise<void> => {
+  const addSchoolLeaderAccess = async (): Promise<AsyncButtonResult> => {
     await apiFetch(`/api/access/${selectedEntraUserId as NoSlashString}/add`, {
       method: "POST",
       body: {
@@ -115,9 +117,11 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true, callBack: resetAddSchoolLeaderAccess }
   }
 
-  const removeSchoolLeaderAccess = async (entraUserId: string): Promise<void> => {
+  const removeSchoolLeaderAccess = async (entraUserId: string): Promise<AsyncButtonResult> => {
     await apiFetch(`/api/access/${entraUserId as NoSlashString}/remove`, {
       method: "POST",
       body: {
@@ -128,6 +132,8 @@
         "Content-Type": "application/json"
       }
     })
+
+    return { status: 'success', reloadPageData: true }
   }
 </script>
 
@@ -187,7 +193,7 @@
         </div>
 
         <div class="update-school-actions">
-          <AsyncButton onClick={updateSchool} buttonText="Lagre" iconName="save" reloadPageDataOnSuccess={true} disabled={isDisabled()} />
+          <AsyncButton onClick={updateSchool} buttonText="Lagre" iconName="save" disabled={isDisabled()} />
           <button class="ds-button" type="button" data-variant="secondary" onclick={abortUpdateSchool}>
             <span class="material-symbols-outlined">close</span>
             Avbryt
@@ -214,7 +220,7 @@
             <tr>
               <td>{schoolLeader.entra.displayName} ({schoolLeader.entra.companyName})</td>
               <td>
-                <AsyncButton onClick={() => removeSchoolLeaderAccess(schoolLeader.entra.id)} reloadPageDataOnSuccess={true} buttonText="Fjern skoleleder" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
+                <AsyncButton onClick={() => removeSchoolLeaderAccess(schoolLeader.entra.id)} buttonText="Fjern skoleleder" iconName="cancel" variant="secondary" color="danger" dataSize="sm" />
               </td>
             </tr>
           {/each}
@@ -232,7 +238,7 @@
         <SuggestionSelect items={suggestionSelectUsers} bind:value={selectedEntraUserId} label="Velg bruker" />
 
         <div class="new-access-actions">
-          <AsyncButton onClick={addSchoolLeaderAccess} buttonText="Legg til skoleleder" reloadPageDataOnSuccess={true} iconName="add" callBackAfterReloadPageData={resetAddSchoolLeaderAccess} />
+          <AsyncButton onClick={addSchoolLeaderAccess} buttonText="Legg til skoleleder" iconName="add" />
 
           <button class="ds-button" type="button" data-variant="secondary" onclick={resetAddSchoolLeaderAccess}>
             <span class="material-symbols-outlined">close</span>

--- a/src/routes/system/schools/[schoolnumber]/+page.svelte
+++ b/src/routes/system/schools/[schoolnumber]/+page.svelte
@@ -48,7 +48,7 @@
     const confirmDelete = confirm(`Er du sikker på at du vil slette skolen "${currentSchool.name}"? Dette kan ikke angres.`)
 
     if (!confirmDelete) {
-      return { status: 'cancelled' }
+      return { status: "cancelled" }
     }
 
     await apiFetch(`/api/schools/${currentSchool.schoolNumber as NoSlashString}`, {
@@ -58,7 +58,7 @@
     // redirect to schools admin page and reload dependent data
     await goto("/system/schools", { invalidateAll: true })
 
-    return { status: 'success' }
+    return { status: "success" }
   }
 
   let selectedEntraUserId = $state("")
@@ -69,11 +69,11 @@
 
   const updateSchool = async (): Promise<AsyncButtonResult> => {
     if (!updateSchoolForm?.reportValidity()) {
-      return { status: 'error', message: INVALID_FORM_MESSAGE }
+      return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
     if (!updateSchoolName) {
-      return { status: 'error', message: "Skolenavn må fylles ut" }
+      return { status: "error", message: "Skolenavn må fylles ut" }
     }
 
     const updateSchoolInput: UpdateSchool = {
@@ -89,7 +89,13 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: () => { updateSchoolEdit = false } }
+    return {
+      status: "success",
+      reloadPageData: true,
+      callBack: () => {
+        updateSchoolEdit = false
+      }
+    }
   }
 
   const abortUpdateSchool = () => {
@@ -118,7 +124,7 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true, callBack: resetAddSchoolLeaderAccess }
+    return { status: "success", reloadPageData: true, callBack: resetAddSchoolLeaderAccess }
   }
 
   const removeSchoolLeaderAccess = async (entraUserId: string): Promise<AsyncButtonResult> => {
@@ -133,7 +139,7 @@
       }
     })
 
-    return { status: 'success', reloadPageData: true }
+    return { status: "success", reloadPageData: true }
   }
 </script>
 

--- a/src/routes/system/schools/[schoolnumber]/+page.svelte
+++ b/src/routes/system/schools/[schoolnumber]/+page.svelte
@@ -69,11 +69,11 @@
 
   const updateSchool = async (): Promise<AsyncButtonResult> => {
     if (!updateSchoolForm?.reportValidity()) {
-      throw new Error(INVALID_FORM_MESSAGE)
+      return { status: 'error', message: INVALID_FORM_MESSAGE }
     }
 
     if (!updateSchoolName) {
-      throw new Error("Skolenavn må være fylt ut")
+      return { status: 'error', message: "Skolenavn må fylles ut" }
     }
 
     const updateSchoolInput: UpdateSchool = {


### PR DESCRIPTION
### Minor commits:
- feat: introduced return types in AsyncButton for simpler and more explicit control (5936ffb)

### Patch commits:
- fix: return instead of throw (9c172e0)
- fix: use new implementation of AsyncButton (877c0f7)
- fix: disable save button if document has not been edited (0a060de)

### Maintenance commits:
- chore: lint:fix (b0bd553)
- chore: lint:fix (6ff54de)
- chore: removed unused import (bedbe92)

### Other commits:
- Merge remote-tracking branch 'origin/main' into todos-and-cleanup (a37bed9)
