### PR TITLE
minor: 1.0.0 - editable-draft-rune

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,12 @@
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/luxon": "^3.7.1",
         "@types/node": "^25.9.1",
+        "happy-dom": "^20.9.0",
         "svelte": "^5.55.9",
         "svelte-check": "^4.4.8",
         "typescript": "^6.0.3",
-        "vite": "^8.0.14"
+        "vite": "^8.0.14",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1214,10 +1216,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1261,6 +1281,13 @@
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
@@ -1268,6 +1295,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@u-elements/u-combobox": {
@@ -1312,6 +1349,129 @@
         "prom-client": "^15.1.3"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1331,6 +1491,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/axobject-query": {
@@ -1412,6 +1582,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1447,6 +1627,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -1515,6 +1702,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -1523,6 +1723,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
@@ -1560,6 +1767,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1613,6 +1830,24 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.3",
@@ -2177,6 +2412,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2480,6 +2722,13 @@
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2556,6 +2805,20 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2684,6 +2947,23 @@
         "bintrees": "1.0.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2698,6 +2978,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2863,11 +3153,111 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -2885,11 +3275,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "test": "tsc --noEmit && biome check && npm run check && npm run build",
+    "test:vite": "vitest --watch=false",
+    "test": "tsc --noEmit && biome check && npm run check && npm run test:vite && npm run build",
     "lint": "npx @biomejs/biome check",
     "lint:fix": "npx @biomejs/biome check --write"
   },
@@ -21,10 +22,12 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.9.1",
+    "happy-dom": "^20.9.0",
     "svelte": "^5.55.9",
     "svelte-check": "^4.4.8",
     "typescript": "^6.0.3",
-    "vite": "^8.0.14"
+    "vite": "^8.0.14",
+    "vitest": "^4.1.7"
   },
   "dependencies": {
     "@digdir/designsystemet-css": "^1.14.0",

--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -3,6 +3,7 @@
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import AsyncButton, { type AsyncButtonResult } from "$lib/components/AsyncButton.svelte"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentAccessPerson } from "$lib/types/app-types"
   import type { AuditEntryInput, DocumentInput, GroupDocument, MetricCount, SchoolInfo, StudentDocument } from "$lib/types/db/shared-types"
@@ -26,18 +27,6 @@
 
   let { document, accessSchools, canEditDocument, canRemoveDocument, studentName, groupName, studentDataSharingConsent, studentAccessPersons, referencedOpen = false }: PageProps = $props()
 
-  const editableDocumentFromDocument = () => {
-    return JSON.parse(
-      JSON.stringify({
-        content: document.content,
-        school: document.school,
-        template: document.template,
-        title: document.title,
-        documentAccess: document.documentAccess || "EXCLUDE_SUBJECT_TEACHERS", // default value, because old documents doesn't have this field, and we don't want to break the editor for those
-        emailAlertReceivers: document.emailAlertReceivers || []
-      } as DocumentInput)
-    )
-  }
 
   let documentDialog: HTMLDialogElement | undefined = $state()
 
@@ -171,11 +160,15 @@
     return { status: "error", message: "Document was neither student or group document??" }
   }
 
-  // svelte-ignore state_referenced_locally - det går bra så lenge denne komponenten remounts ved endring av document (ha en key på document i parent)
-  let editableDocument: DocumentInput = $state(editableDocumentFromDocument())
-
-  let documentEdited: boolean = $derived.by(() => {
-    return JSON.stringify(editableDocumentFromDocument()) !== JSON.stringify(editableDocument)
+  let editableDocument: EditableDraft<DocumentInput> = createEditableDraft(() => {
+    return {
+      content: document.content,
+      school: document.school,
+      template: document.template,
+      title: document.title,
+      documentAccess: document.documentAccess || "EXCLUDE_SUBJECT_TEACHERS",
+      emailAlertReceivers: document.emailAlertReceivers || []
+    }
   })
 
   let editMode = $state(false)
@@ -190,7 +183,7 @@
           <span class="material-symbols-outlined" data-tooltip="Dette notatet er skrivebeskyttet fordi det tilhører et tidligere skoleår">lock</span>
         {/if}
       </div>
-      <button id="document-modal-{document._id}-open" class="ds-button card-button" onclick={() => handleDocumentOpen(document)} data-size="lg" data-variant="tertiary" aria-label="{document.template.name}: {editableDocument.title}">{document.template.name}</button>
+      <button id="document-modal-{document._id}-open" class="ds-button card-button" onclick={() => handleDocumentOpen(document)} data-size="lg" data-variant="tertiary" aria-label="{document.template.name}: {document.title}">{document.template.name}</button>
       <p class="ds-paragraph" style="margin: 0;">{document.title}</p>
       <EditorInfo editorInfo={document.created} isEdited={document.modified.at.getTime() > document.created.at.getTime()} timestamp={false} modifiedIndicator={true} style="margin-top: var(--ds-size-2);" />
     </div>
@@ -216,7 +209,7 @@
           </span>
           <span class="ds-tag" data-color="brand1" data-size="lg">
             <span class="material-symbols-outlined" style="margin-right: var(--ds-size-2);">school</span>
-            {studentName || groupName} - {editableDocument.school.name}
+            {studentName || groupName} - {editableDocument.draft.school.name}
           </span>
           {#if document.isDocumentLocked}
             <span class="ds-tag" data-color="danger" data-size="lg" data-tooltip="Dette notatet er skrivebeskyttet fordi det tilhører et tidligere skoleår">
@@ -226,7 +219,7 @@
         </div>
 
         {#if !editMode}
-          <h2 class="ds-heading" style="font-weight: bold;">{editableDocument.title}</h2>
+          <h2 class="ds-heading" style="font-weight: bold;">{document.title}</h2>
           <EditorInfo editorInfo={document.created} isEdited={document.modified.at.getTime() > document.created.at.getTime()} timestamp={true} modifiedIndicator={true} />
         {/if}
       </div>
@@ -238,7 +231,7 @@
           {/each}
 
         {:else}
-          <DocumentEditor documentId={document._id} studentId={"student" in document ? document.student._id : undefined} groupSystemId={"group" in document ? document.group.systemId : undefined} bind:currentDocument={editableDocument} {accessSchools} {documentEdited} closeEditor={() => { editMode = false; editableDocument = editableDocumentFromDocument(); }} />
+          <DocumentEditor documentId={document._id} studentId={"student" in document ? document.student._id : undefined} groupSystemId={"group" in document ? document.group.systemId : undefined} bind:currentDocument={editableDocument.draft} {accessSchools} documentEdited={editableDocument.isDirty} closeEditor={() => { editMode = false; editableDocument.cancel() }} />
         {/if}
 
         <div class="document-footer">

--- a/src/lib/components/Document/Document.svelte
+++ b/src/lib/components/Document/Document.svelte
@@ -27,7 +27,6 @@
 
   let { document, accessSchools, canEditDocument, canRemoveDocument, studentName, groupName, studentDataSharingConsent, studentAccessPersons, referencedOpen = false }: PageProps = $props()
 
-
   let documentDialog: HTMLDialogElement | undefined = $state()
 
   let originalDialogParent: HTMLElement | undefined = $state()

--- a/src/lib/components/Document/Message.svelte
+++ b/src/lib/components/Document/Message.svelte
@@ -2,6 +2,7 @@
   import { page } from "$app/state"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import { canEditDocumentMessage } from "$lib/shared-authorization/authorization"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentAccessPerson } from "$lib/types/app-types"
@@ -22,26 +23,8 @@
 
   let { document, message, editMode, studentDataSharingConsent, studentAccessPersons, emailAlertAvailable, callback }: PageProps = $props()
 
-  // svelte-ignore state_referenced_locally (we don't want to modify the original), remember key on the outside
-  let editableMessage: DocumentMessageInput = $state({
-    type: message.type,
-    content: {
-      title: message.content.title,
-      text: message.content.text
-    },
-    emailAlertReceivers: message.emailAlertReceivers || []
-  })
-
-  let canEditMessage: boolean = $derived.by(() => canEditDocumentMessage(page.data.authenticatedPrincipal, message))
-
-  let messageEdited = $derived.by(() => {
-    return editableMessage.type !== message.type || editableMessage.content.title !== message.content.title || editableMessage.content.text !== message.content.text
-  })
-
-  let messageForm: HTMLFormElement | undefined = $state()
-
-  const callBackOnSuccessOrCancel = () => {
-    editableMessage = {
+  let messageSource: DocumentMessageInput = $derived.by(() => {
+    return {
       type: message.type,
       content: {
         title: message.content.title,
@@ -49,6 +32,16 @@
       },
       emailAlertReceivers: message.emailAlertReceivers || []
     }
+  })
+
+  let editableMessage: EditableDraft<DocumentMessageInput> = createEditableDraft(() => messageSource)
+
+  let canEditMessage: boolean = $derived.by(() => canEditDocumentMessage(page.data.authenticatedPrincipal, message))
+
+  let messageForm: HTMLFormElement | undefined = $state()
+
+  const callBackOnSuccessOrCancel = () => {
+    editableMessage.cancel()
 
     if (callback) {
       callback()
@@ -72,7 +65,7 @@
 
       await apiFetch(createMessageRoute, {
         method: "POST",
-        body: editableMessage,
+        body: editableMessage.draft,
         headers: {
           "Content-Type": "application/json"
         }
@@ -86,7 +79,7 @@
 
       await apiFetch(createMessageRoute, {
         method: "POST",
-        body: editableMessage,
+        body: editableMessage.draft,
         headers: {
           "Content-Type": "application/json"
         }
@@ -115,7 +108,7 @@
 
       await apiFetch(updateMessageRoute, {
         method: "PATCH",
-        body: editableMessage,
+        body: editableMessage.draft,
         headers: {
           "Content-Type": "application/json"
         }
@@ -129,7 +122,7 @@
 
       await apiFetch(updateMessageRoute, {
         method: "PATCH",
-        body: editableMessage,
+        body: editableMessage.draft,
         headers: {
           "Content-Type": "application/json"
         }
@@ -151,13 +144,13 @@
 
   {#if editMode}
     <form bind:this={messageForm}>
-      {#if editableMessage.type === "update"}
+      {#if editableMessage.draft.type === "update"}
         <ds-field class="ds-field content-item">
           <label for="message-title-{message.messageId || document._id}" class="ds-label" data-weight="medium">
             Tittel
             <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
           </label>
-          <input autocomplete="off" class="ds-input" type="text" id="message-title-{message.messageId || document._id}" name="messageTitle" required bind:value={editableMessage.content.title} />
+          <input autocomplete="off" class="ds-input" type="text" id="message-title-{message.messageId || document._id}" name="messageTitle" required bind:value={editableMessage.draft.content.title} />
         </ds-field>
         
         <ds-field class="ds-field content-item">
@@ -165,7 +158,7 @@
             Oppdatering
             <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
           </label>
-          <textarea required class="ds-input" name="messageContent" id="message-content-{message.messageId || document._id}" rows={5} bind:value={editableMessage.content.text}></textarea>
+          <textarea required class="ds-input" name="messageContent" id="message-content-{message.messageId || document._id}" rows={5} bind:value={editableMessage.draft.content.text}></textarea>
         </ds-field>
       {/if}
 
@@ -179,7 +172,7 @@
           {studentDataSharingConsent}
           schoolNumber={document.school.schoolNumber}
           documentAccess={document.documentAccess}
-          bind:emailAlertReceivers={editableMessage.emailAlertReceivers}
+          bind:emailAlertReceivers={editableMessage.draft.emailAlertReceivers}
         />
       {/if}
     </form>
@@ -197,7 +190,7 @@
     {#if !message.messageId}
       <AsyncButton buttonText="Lagre" onClick={newMessage} iconName="save" />
     {:else}
-      <AsyncButton disabled={!messageEdited} buttonText="Lagre endringer" onClick={updateMessage} iconName="save" />
+      <AsyncButton disabled={!editableMessage.isDirty} buttonText="Lagre endringer" onClick={updateMessage} iconName="save" />
     {/if}
     <button class="ds-button" data-variant="secondary" onclick={callBackOnSuccessOrCancel}><span class="material-symbols-outlined">close</span>Avbryt</button>
   </div>

--- a/src/lib/components/Document/NewDocument.svelte
+++ b/src/lib/components/Document/NewDocument.svelte
@@ -16,22 +16,21 @@
 
   let { documentContentTemplates, accessSchools, studentId, studentName, groupSystemId, groupName, studentDataSharingConsent, studentAccessPersons }: PageProps = $props()
 
-  // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
-  if (!studentId && !groupSystemId) {
-    throw new Error("Student ID or Group System ID is required to create a new document")
-  }
-  // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
-  if (studentId && groupSystemId) {
-    throw new Error("Both Student ID and Group System ID provided, only one should be provided")
-  }
-  // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
-  if (accessSchools.length === 0) {
-    throw new Error("At least one access school is required to create a new document")
-  }
-  // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId
-  if (documentContentTemplates.length === 0) {
-    throw new Error("At least one document content template is required to create a new document")
-  }
+  let _pagePropsGuard = $derived.by(() => { 
+    if (!studentId && !groupSystemId) {
+      throw new Error("Student ID or Group System ID is required to create a new document")
+    }
+    if (studentId && groupSystemId) {
+      throw new Error("Both Student ID and Group System ID provided, only one should be provided")
+    }
+    if (accessSchools.length === 0) {
+      throw new Error("At least one access school is required to create a new document")
+    }
+    if (documentContentTemplates.length === 0) {
+      throw new Error("At least one document content template is required to create a new document")
+    }
+    return true
+  })
 
   let newDocumentDialog: HTMLDialogElement | undefined
 
@@ -50,8 +49,7 @@
     }
   }
 
-  // svelte-ignore state_referenced_locally det går bra så lenge denne komponenten remounts ved endring av studentId/groupSystemId TODO - sjekk om det skal være derived
-  const newDocumentTemplates = documentContentTemplates.map((template) => newDocumentTemplate(template))
+  const newDocumentTemplates = $derived.by(() => documentContentTemplates.map((template) => newDocumentTemplate(template)))
 
   let newDocument: DocumentInput | null = $state(null)
 

--- a/src/lib/components/Document/NewDocument.svelte
+++ b/src/lib/components/Document/NewDocument.svelte
@@ -16,7 +16,7 @@
 
   let { documentContentTemplates, accessSchools, studentId, studentName, groupSystemId, groupName, studentDataSharingConsent, studentAccessPersons }: PageProps = $props()
 
-  let _pagePropsGuard = $derived.by(() => { 
+  $effect(() => {
     if (!studentId && !groupSystemId) {
       throw new Error("Student ID or Group System ID is required to create a new document")
     }
@@ -29,7 +29,6 @@
     if (documentContentTemplates.length === 0) {
       throw new Error("At least one document content template is required to create a new document")
     }
-    return true
   })
 
   let newDocumentDialog: HTMLDialogElement | undefined

--- a/src/lib/components/ImportantGroupStuff.svelte
+++ b/src/lib/components/ImportantGroupStuff.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { ClassGroup, GroupImportantStuff, GroupImportantStuffInput, SchoolInfo } from "$lib/types/db/shared-types"
   import AsyncButton, { type AsyncButtonResult } from "./AsyncButton.svelte"
@@ -17,19 +18,12 @@
   let editMode = $state(false)
   let groupImportantStuffForm: HTMLFormElement | undefined = $state()
 
-  let savedEditableGroupImportantStuff: GroupImportantStuffInput = $derived.by(() => {
-    return {
-      school: school,
-      importantInfo: groupImportantStuff?.importantInfo || ""
-    }
-  })
+  let groupImportantStuffSource: GroupImportantStuffInput = $derived.by(() => ({
+    school,
+    importantInfo: groupImportantStuff?.importantInfo || ""
+  }))
 
-  // svelte-ignore state_referenced_locally - det går bra, vi håndterer intern state i klassen EditableGroupImportantStuffHandler
-  let editableGroupImportantStuff: GroupImportantStuffInput = $state(savedEditableGroupImportantStuff)
-
-  let hasMadeChanges = $derived.by(() => {
-    return JSON.stringify(savedEditableGroupImportantStuff) !== JSON.stringify(editableGroupImportantStuff)
-  })
+  let editableGroupImportantStuff: EditableDraft<GroupImportantStuffInput> = createEditableDraft(() => groupImportantStuffSource)
 
   const updateGroupImportantStuff = async (): Promise<AsyncButtonResult> => {
     if (!groupImportantStuffForm) {
@@ -43,7 +37,7 @@
 
     await apiFetch(`/api/classes/${group.systemId as NoSlashString}/importantstuff`, {
       method: "PATCH",
-      body: editableGroupImportantStuff,
+      body: editableGroupImportantStuff.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -80,11 +74,11 @@
             <div data-field="description">
               Skriv inn informasjon om klassen
             </div>
-            <textarea rows="5" bind:value={editableGroupImportantStuff.importantInfo} class="ds-input"></textarea>
+            <textarea rows="5" bind:value={editableGroupImportantStuff.draft.importantInfo} class="ds-input"></textarea>
           </ds-field>
         {:else}
           <p class="ds-paragraph important-info-text">
-            {savedEditableGroupImportantStuff.importantInfo || "Ingen informasjon lagt til"}
+            {groupImportantStuffSource.importantInfo || "Ingen informasjon lagt til"}
           </p>
         {/if}
       </div>
@@ -93,8 +87,8 @@
 
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={updateGroupImportantStuff} buttonText="Lagre" iconName="save" />
-      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableGroupImportantStuff = $state.snapshot(savedEditableGroupImportantStuff); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
+      <AsyncButton disabled={!editableGroupImportantStuff.isDirty} onClick={updateGroupImportantStuff} buttonText="Lagre" iconName="save" />
+      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableGroupImportantStuff.cancel() }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}
     {#if groupImportantStuff?.modified && !editMode}

--- a/src/lib/components/SchoolAdministration/ProgramArea.svelte
+++ b/src/lib/components/SchoolAdministration/ProgramArea.svelte
@@ -3,6 +3,7 @@
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { nameValidation } from "$lib/data-validation/program-area-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { AccessControlClass } from "$lib/types/app-types"
   import type { ProgramArea, ProgramAreaInput } from "$lib/types/db/shared-types"
@@ -17,12 +18,13 @@
 
   let { programArea = undefined, schoolClasses, schoolNumber, editMode = $bindable(false) }: ProgramAreaProps = $props()
 
-  // svelte-ignore state_referenced_locally - det går bra så lenge du har en key på _id utsida
-  let editableProgramAreaName: string = $state(programArea?.name || "")
+  let editableProgramArea: EditableDraft<{ name: string }> = createEditableDraft(() => {
+    return { name: programArea?.name || "" }
+  })
+
+  let classesChanged = $state(false)
   let classesSuggestionElement: DSSuggestionElement | undefined = $state()
   let programAreaForm: HTMLFormElement | undefined = $state()
-
-  let programAreaEdited = $state(false)
 
   let nonExistingProgramAreas: string[] = $derived.by(() => {
     if (!programArea) {
@@ -33,21 +35,14 @@
   })
 
   const programAreaHasBeenEdited = (): void => {
-    if (!programArea) {
-      programAreaEdited = false
+    if (!programArea || !classesSuggestionElement) {
+      classesChanged = false
       return
     }
 
-    const nameChanged = editableProgramAreaName !== programArea.name
-    let classesChanged = false
-    if (classesSuggestionElement) {
-      const selectedClassIds = classesSuggestionElement.values
-      const originalClassIds = programArea.classes?.map((classGroup) => classGroup.systemId) || []
-      // Sjekk om de valgte klassene er forskjellige fra de originale
-      classesChanged = selectedClassIds.length !== originalClassIds.length || !selectedClassIds.every((id) => originalClassIds.includes(id))
-    }
-
-    programAreaEdited = nameChanged || classesChanged
+    const selectedClassIds = classesSuggestionElement.values
+    const originalClassIds = programArea.classes?.map((classGroup) => classGroup.systemId) || []
+    classesChanged = selectedClassIds.length !== originalClassIds.length || !selectedClassIds.every((id) => originalClassIds.includes(id))
   }
 
   const validateAndGetProgramAreaInput = (): ProgramAreaInput => {
@@ -55,7 +50,7 @@
       throw new Error(INVALID_FORM_MESSAGE)
     }
 
-    if (!editableProgramAreaName) {
+    if (!editableProgramArea.draft.name) {
       throw new Error("Navn på programområde må være fylt ut")
     }
 
@@ -64,12 +59,12 @@
     }
 
     return {
-      name: editableProgramAreaName,
+      name: editableProgramArea.draft.name,
       classes: classesSuggestionElement.values
         .map((value) => {
           const matchingClass = schoolClasses.find((classGroup) => classGroup.systemId === value)
           if (!matchingClass) {
-            console.warn("Klasse med systemId", value, "ikke funnet. Den vil bli fjernet fra programområde", editableProgramAreaName)
+            console.warn("Klasse med systemId", value, "ikke funnet. Den vil bli fjernet fra programområde", editableProgramArea.draft.name)
             return null
           }
 
@@ -129,8 +124,8 @@
 
   const closeEditMode = (): void => {
     editMode = false
-    editableProgramAreaName = programArea?.name || ""
-    programAreaEdited = false
+    editableProgramArea.cancel()
+    classesChanged = false
   }
 </script>
 
@@ -150,7 +145,7 @@
           <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
         </label>
         <div class="ds-field-affixes">
-          <input class="ds-input" type="text" id="program-area-name" maxlength={nameValidation.maxLength} minlength={nameValidation.minLength} pattern={nameValidation.pattern.source} bind:value={editableProgramAreaName} oninput={programAreaHasBeenEdited} required>
+          <input class="ds-input" type="text" id="program-area-name" maxlength={nameValidation.maxLength} minlength={nameValidation.minLength} pattern={nameValidation.pattern.source} bind:value={editableProgramArea.draft.name} required>
         </div>
       </ds-field>
 
@@ -194,7 +189,7 @@
 
     <div class="program-area-actions">
       {#if programArea}
-        <AsyncButton disabled={!programAreaEdited && nonExistingProgramAreas.length === 0} onClick={updateProgramArea} buttonText="Lagre endringer" iconName="save" />
+        <AsyncButton disabled={!editableProgramArea.isDirty && !classesChanged && nonExistingProgramAreas.length === 0} onClick={updateProgramArea} buttonText="Lagre endringer" iconName="save" />
         <AsyncButton onClick={deleteProgramArea} buttonText="Slett programområde" iconName="delete" color="danger" />
       {:else}
         <AsyncButton onClick={createProgramArea} buttonText="Opprett programområde" iconName="save" />

--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -2,6 +2,7 @@
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { studentDataSharingConsentMessageValidation } from "$lib/data-validation/student-consent-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte";
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { FrontendStudent, StudentUnavailableSchoolDocuments } from "$lib/types/app-types"
   import type { StudentDataSharingConsent, StudentDataSharingConsentInput } from "$lib/types/db/shared-types"
@@ -20,19 +21,11 @@
   let editMode = $state(false)
   let consentForm: HTMLFormElement | undefined = $state()
 
-  // svelte-ignore state_referenced_locally - det går bra så lenge denne komponenten remounts ved endring av student
-  const savedEditableSharingConsent: StudentDataSharingConsentInput = $derived.by(() => {
+  let editableSharingConsent: EditableDraft<StudentDataSharingConsentInput> = createEditableDraft(() => {
     return {
       consent: studentDataSharingConsent?.consent ?? false,
       message: studentDataSharingConsent?.message ?? ""
     }
-  })
-
-  // svelte-ignore state_referenced_locally - det går bra, vi ønsker en lokal kopi
-  let editableSharingConsent: StudentDataSharingConsentInput = $state(savedEditableSharingConsent)
-
-  let hasMadeChanges = $derived.by(() => {
-    return JSON.stringify(savedEditableSharingConsent) !== JSON.stringify(editableSharingConsent)
   })
 
   const updateStudentDataSharingConsent = async (): Promise<AsyncButtonResult> => {
@@ -46,7 +39,7 @@
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/consent`, {
       method: "PATCH",
-      body: editableSharingConsent,
+      body: editableSharingConsent.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -79,7 +72,7 @@
     {#if editMode}
       <form bind:this={consentForm}>
         <ds-field class="ds-field">
-          <input id="sharing-consent-checkbox" class="ds-input" type="checkbox" bind:checked={editableSharingConsent.consent} />
+          <input id="sharing-consent-checkbox" class="ds-input" type="checkbox" bind:checked={editableSharingConsent.draft.consent} />
           <label class="ds-label" data-weight="regular" for="sharing-consent-checkbox">Eleven har samtykket til deling av notater på tvers av skoler</label>
           <!--<div data-field="description">Description</div>-->
         </ds-field>
@@ -90,14 +83,14 @@
           <div data-field="description">
             Hvor er samtykket dokumentert, eventuelt annen relevant informasjon om samtykket
           </div>
-          <textarea id="sharing-consent-message" rows="4" required={editableSharingConsent.consent} minlength={editableSharingConsent.consent ? studentDataSharingConsentMessageValidation.minLength : 0} maxlength={studentDataSharingConsentMessageValidation.maxLength} bind:value={editableSharingConsent.message} class="ds-input"></textarea>
+          <textarea id="sharing-consent-message" rows="4" required={editableSharingConsent.draft.consent} minlength={editableSharingConsent.draft.consent ? studentDataSharingConsentMessageValidation.minLength : 0} maxlength={studentDataSharingConsentMessageValidation.maxLength} bind:value={editableSharingConsent.draft.message} class="ds-input"></textarea>
         </ds-field>
       </form>
     {:else}
-      <p class="ds-paragraph">Eleven har {savedEditableSharingConsent.consent ? "samtykket til deling av data" : "ikke samtykket til deling av data"}</p>
-      {#if savedEditableSharingConsent.message}
+      <p class="ds-paragraph">Eleven har {studentDataSharingConsent?.consent ? "samtykket til deling av data" : "ikke samtykket til deling av data"}</p>
+      {#if studentDataSharingConsent?.message}
         <h3 class="ds-heading" data-size="xs">Dokumentasjon</h3>
-        <p class="ds-paragraph">{savedEditableSharingConsent.message}</p>
+        <p class="ds-paragraph">{studentDataSharingConsent.message}</p>
       {/if}
 
       {#if unavailableSchoolDocuments.length > 0}
@@ -112,8 +105,8 @@
   </div>
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={updateStudentDataSharingConsent} buttonText="Lagre" iconName="save" />
-      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableSharingConsent = $state.snapshot(savedEditableSharingConsent); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
+      <AsyncButton disabled={!editableSharingConsent.isDirty} onClick={updateStudentDataSharingConsent} buttonText="Lagre" iconName="save" />
+      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableSharingConsent.cancel() }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}
     {#if studentDataSharingConsent?.modified && !editMode}

--- a/src/lib/components/StudentBoxes/DataSharingConsent.svelte
+++ b/src/lib/components/StudentBoxes/DataSharingConsent.svelte
@@ -2,7 +2,7 @@
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { studentDataSharingConsentMessageValidation } from "$lib/data-validation/student-consent-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
-  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte";
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { FrontendStudent, StudentUnavailableSchoolDocuments } from "$lib/types/app-types"
   import type { StudentDataSharingConsent, StudentDataSharingConsentInput } from "$lib/types/db/shared-types"

--- a/src/lib/components/StudentBoxes/ImportantStuff.svelte
+++ b/src/lib/components/StudentBoxes/ImportantStuff.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { FrontendStudent } from "$lib/types/app-types"
   import type { SchoolInfo, StudentCheckBox, StudentImportantStuff, StudentImportantStuffInput } from "$lib/types/db/shared-types"
@@ -21,21 +22,14 @@
   let editMode = $state(false)
   let importantStuffForm: HTMLFormElement | undefined = $state()
 
-  let savedEditableImportantStuff: StudentImportantStuffInput = $derived.by(() => {
-    return {
-      school: school,
-      importantInfo: importantStuff?.importantInfo || "",
-      facilitation: importantStuff?.facilitation.filter((facilitationId) => studentCheckBoxes.find((checkbox) => checkbox._id === facilitationId && checkbox.enabled)) || [],
-      followUp: importantStuff?.followUp.filter((followUpId) => studentCheckBoxes.find((checkbox) => checkbox._id === followUpId && checkbox.enabled)) || []
-    }
-  })
+  let importantStuffSource: StudentImportantStuffInput = $derived.by(() => ({
+    school,
+    importantInfo: importantStuff?.importantInfo || "",
+    facilitation: importantStuff?.facilitation.filter((facilitationId) => studentCheckBoxes.find((checkbox) => checkbox._id === facilitationId && checkbox.enabled)) || [],
+    followUp: importantStuff?.followUp.filter((followUpId) => studentCheckBoxes.find((checkbox) => checkbox._id === followUpId && checkbox.enabled)) || []
+  }))
 
-  // svelte-ignore state_referenced_locally - det går bra, vi håndterer intern state i klassen EditableImportantStuffHandler
-  let editableImportantStuff: StudentImportantStuffInput = $state(savedEditableImportantStuff)
-
-  let hasMadeChanges = $derived.by(() => {
-    return JSON.stringify(savedEditableImportantStuff) !== JSON.stringify(editableImportantStuff)
-  })
+  let editableImportantStuff: EditableDraft<StudentImportantStuffInput> = createEditableDraft(() => importantStuffSource)
 
   const getStudentCheckBoxValues = (checkboxIds: string[]): string[] => {
     return checkboxIds
@@ -56,7 +50,7 @@
 
     await apiFetch(`/api/students/${student._id as NoSlashString}/importantstuff`, {
       method: "PATCH",
-      body: editableImportantStuff,
+      body: editableImportantStuff.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -93,11 +87,11 @@
             <div data-field="description">
               Skriv inn informasjon som eleven har godtatt at deles
             </div>
-            <textarea rows="5" bind:value={editableImportantStuff.importantInfo} class="ds-input"></textarea>
+            <textarea rows="5" bind:value={editableImportantStuff.draft.importantInfo} class="ds-input"></textarea>
           </ds-field>
         {:else}
           <p class="ds-paragraph important-info-text">
-            {savedEditableImportantStuff.importantInfo || "Ingen informasjon lagt til"}
+            {importantStuffSource.importantInfo || "Ingen informasjon lagt til"}
           </p>
         {/if}
       </div>
@@ -109,17 +103,17 @@
             <fieldset class="ds-fieldset">
               {#each studentCheckBoxes.filter(checkbox => checkbox.enabled && checkbox.type === "FOLLOW_UP") as followUpCheckbox}
                 <ds-field class="ds-field">
-                  <input id={followUpCheckbox._id} class="ds-input" type="checkbox" bind:group={editableImportantStuff.followUp} value={followUpCheckbox._id} />
+                  <input id={followUpCheckbox._id} class="ds-input" type="checkbox" bind:group={editableImportantStuff.draft.followUp} value={followUpCheckbox._id} />
                   <label for={followUpCheckbox._id} class="ds-label" data-weight="regular">{followUpCheckbox.value}</label>
                 </ds-field>
               {/each}
             </fieldset>
           {:else}
-            {#if savedEditableImportantStuff.followUp.length === 0}
+            {#if importantStuffSource.followUp.length === 0}
               Ingen {STUDENT_CHECKBOX_DISPLAY_NAMES.FOLLOW_UP.plural.toLowerCase()}
             {:else}
               <ul class="ds-list">
-                {#each getStudentCheckBoxValues(savedEditableImportantStuff.followUp) as followUpValue}
+                {#each getStudentCheckBoxValues(importantStuffSource.followUp) as followUpValue}
                   <li>{followUpValue}</li>
                 {/each}
               </ul>
@@ -133,17 +127,17 @@
             <fieldset class="ds-fieldset">
               {#each studentCheckBoxes.filter(checkbox => checkbox.enabled && checkbox.type === "FACILITATION") as facilitationCheckbox}
                 <ds-field class="ds-field">
-                  <input id={facilitationCheckbox._id} class="ds-input" type="checkbox" bind:group={editableImportantStuff.facilitation} value={facilitationCheckbox._id} />
+                  <input id={facilitationCheckbox._id} class="ds-input" type="checkbox" bind:group={editableImportantStuff.draft.facilitation} value={facilitationCheckbox._id} />
                   <label for={facilitationCheckbox._id} class="ds-label" data-weight="regular">{facilitationCheckbox.value}</label>
                 </ds-field>
               {/each}
             </fieldset>
           {:else}
-            {#if savedEditableImportantStuff.facilitation.length === 0}
+            {#if importantStuffSource.facilitation.length === 0}
               Ingen {STUDENT_CHECKBOX_DISPLAY_NAMES.FACILITATION.plural.toLowerCase()}
             {:else}
               <ul class="ds-list">
-                {#each getStudentCheckBoxValues(savedEditableImportantStuff.facilitation) as facilitationValue}
+                {#each getStudentCheckBoxValues(importantStuffSource.facilitation) as facilitationValue}
                   <li>{facilitationValue}</li>
                 {/each}
               </ul>
@@ -156,8 +150,8 @@
 
   {#if editMode}
     <div class="card-footer-actions">
-      <AsyncButton disabled={!hasMadeChanges} onClick={updateStudentImportantStuff} buttonText="Lagre" iconName="save" />
-      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableImportantStuff = $state.snapshot(savedEditableImportantStuff); }}><span class="material-symbols-outlined">close</span>Avbryt</button>
+      <AsyncButton disabled={!editableImportantStuff.isDirty} onClick={updateStudentImportantStuff} buttonText="Lagre" iconName="save" />
+      <button class="ds-button" data-variant="secondary" type="button" onclick={() => { editMode = false; editableImportantStuff.cancel() }}><span class="material-symbols-outlined">close</span>Avbryt</button>
     </div>
   {:else}
     {#if importantStuff?.modified && !editMode}

--- a/src/lib/components/StudentCheckBox.svelte
+++ b/src/lib/components/StudentCheckBox.svelte
@@ -18,14 +18,12 @@
 
   let { checkBox, editMode, name, callBackOnCreate, callBackOnCancel }: StudentCheckBoxProps = $props()
 
-  let checkBoxSource = $derived.by(() => ({
+  let editableCheckBox: EditableDraft<StudentCheckBoxInput> = createEditableDraft(() => ({
     enabled: checkBox.enabled,
     type: checkBox.type,
     value: checkBox.value,
     sort: checkBox.sort
   }))
-
-  let editableCheckBox: EditableDraft<StudentCheckBoxInput> = createEditableDraft(() => checkBoxSource)
 
   let studentCheckBoxFormNew: HTMLFormElement | undefined = $state()
   let studentCheckBoxFormEditName: HTMLFormElement | undefined = $state()

--- a/src/lib/components/StudentCheckBox.svelte
+++ b/src/lib/components/StudentCheckBox.svelte
@@ -2,6 +2,7 @@
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { studentCheckBoxValueValidation } from "$lib/data-validation/student-check-box-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { StudentCheckBox, StudentCheckBoxInput } from "$lib/types/db/shared-types"
   import { prettifyDateTime } from "$lib/utils/dates"
@@ -17,13 +18,14 @@
 
   let { checkBox, editMode, name, callBackOnCreate, callBackOnCancel }: StudentCheckBoxProps = $props()
 
-  // svelte-ignore state_referenced_locally - we want a local copy
-  let editableCheckBox: StudentCheckBoxInput = $state({
+  let checkBoxSource = $derived.by(() => ({
     enabled: checkBox.enabled,
     type: checkBox.type,
     value: checkBox.value,
     sort: checkBox.sort
-  } as StudentCheckBoxInput)
+  }))
+
+  let editableCheckBox: EditableDraft<StudentCheckBoxInput> = createEditableDraft(() => checkBoxSource)
 
   let studentCheckBoxFormNew: HTMLFormElement | undefined = $state()
   let studentCheckBoxFormEditName: HTMLFormElement | undefined = $state()
@@ -31,6 +33,7 @@
 
   const cancelStudentCheckBox = (): void => {
     editMode = false
+    editableCheckBox.cancel()
 
     if (callBackOnCancel) {
       callBackOnCancel()
@@ -48,7 +51,7 @@
 
     await apiFetch("/api/studentcheckboxes", {
       method: "POST",
-      body: editableCheckBox,
+      body: editableCheckBox.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -111,7 +114,7 @@
 
     await apiFetch(`/api/studentcheckboxes/${checkBox._id as NoSlashString}`, {
       method: "PATCH",
-      body: editableCheckBox,
+      body: editableCheckBox.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -139,7 +142,7 @@
           <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
         </label>
         <div class="ds-field-affixes">
-          <input class="ds-input" id="studentCheckBoxName" type="text" bind:value={editableCheckBox.value} required minlength={studentCheckBoxValueValidation.minLength} maxlength={studentCheckBoxValueValidation.maxLength}>
+          <input class="ds-input" id="studentCheckBoxName" type="text" bind:value={editableCheckBox.draft.value} required minlength={studentCheckBoxValueValidation.minLength} maxlength={studentCheckBoxValueValidation.maxLength}>
         </div>
       </ds-field>
 
@@ -149,7 +152,7 @@
           <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
         </label>
         <div class="ds-field-affixes">
-          <input class="ds-input" id="studentCheckBoxSort" type="number" bind:value={editableCheckBox.sort} required>
+          <input class="ds-input" id="studentCheckBoxSort" type="number" bind:value={editableCheckBox.draft.sort} required>
         </div>
       </ds-field>
 
@@ -157,7 +160,7 @@
         <label class="ds-label" data-weight="medium" for="studentCheckBoxEnabled" data-clickdelegatefor="studentCheckBoxEnabled">
           Aktiv
         </label>
-        <input class="ds-input" type="checkbox" id="studentCheckBoxEnabled" bind:checked={editableCheckBox.enabled}>
+        <input class="ds-input" type="checkbox" id="studentCheckBoxEnabled" bind:checked={editableCheckBox.draft.enabled}>
       </ds-field>
 
       <div class="student_check_box_edit_actions">
@@ -170,7 +173,7 @@
   <td>
     {#if editMode}
       <form bind:this={studentCheckBoxFormEditName}>
-        <input class="ds-input" id="studentCheckBoxName" type="text" bind:value={editableCheckBox.value} required minlength={studentCheckBoxValueValidation.minLength} maxlength={studentCheckBoxValueValidation.maxLength}>
+        <input class="ds-input" id="studentCheckBoxName" type="text" bind:value={editableCheckBox.draft.value} required minlength={studentCheckBoxValueValidation.minLength} maxlength={studentCheckBoxValueValidation.maxLength}>
       </form>
     {:else}
       {checkBox.value}
@@ -179,7 +182,7 @@
   <td>
     {#if editMode}
       <form bind:this={studentCheckBoxFormEditSort}>
-        <input class="ds-input" id="studentCheckBoxSort" type="number" bind:value={editableCheckBox.sort} required>
+        <input class="ds-input" id="studentCheckBoxSort" type="number" bind:value={editableCheckBox.draft.sort} required>
       </form>
     {:else}
       {checkBox.sort}
@@ -187,7 +190,7 @@
   </td>
   <td>
     {#if editMode}
-      <input class="ds-input" type="checkbox" id="studentCheckBoxEnabled" bind:checked={editableCheckBox.enabled}>
+      <input class="ds-input" type="checkbox" id="studentCheckBoxEnabled" bind:checked={editableCheckBox.draft.enabled}>
     {:else}
       {checkBox.enabled ? "Aktiv" : "Deaktivert (skjult)"}
     {/if}
@@ -214,7 +217,7 @@
         <button class="ds-button" type="button" data-size="sm" onclick={() => editMode = true}><span class="material-symbols-outlined">edit</span>Rediger</button>
         <AsyncButton onClick={deleteStudentCheckBox} buttonText="Slett" iconName="delete" dataSize="sm" color="danger" />
       {:else}
-        <AsyncButton onClick={updateStudentCheckBox} buttonText="Lagre" iconName="save" dataSize="sm" />
+        <AsyncButton disabled={!editableCheckBox.isDirty} onClick={updateStudentCheckBox} buttonText="Lagre" iconName="save" dataSize="sm" />
         <button class="ds-button" type="button" data-size="sm" data-variant="secondary" onclick={cancelStudentCheckBox}>Avbryt</button>
       {/if}
     </div>

--- a/src/lib/components/TemplateEditor/TemplateEditor.svelte
+++ b/src/lib/components/TemplateEditor/TemplateEditor.svelte
@@ -2,6 +2,7 @@
   import { goto } from "$app/navigation"
   import { apiFetch } from "$lib/api-fetch/api-fetch"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft, type EditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { DocumentContentItem, DocumentContentTemplate } from "$lib/types/db/shared-types"
   import AsyncButton, { type AsyncButtonResult } from "../AsyncButton.svelte"
@@ -15,10 +16,9 @@
 
   let { template }: TemplateEditorProps = $props()
 
-  // svelte-ignore state_referenced_locally (vi vil ha en kopi her, så kan den bli satt tilbake hvis det trengs via #key)
-  let editableTemplate = $state(template)
+  let editableTemplate: EditableDraft<DocumentContentTemplate> = createEditableDraft(() => template)
 
-  let previewMode = $state(Boolean(editableTemplate._id))
+  let previewMode = $state(Boolean(editableTemplate.draft._id))
 
   let templateForm: HTMLFormElement | undefined = $state()
 
@@ -90,20 +90,20 @@
     if (!newItem) {
       throw new Error("Ugyldig item-type")
     }
-    editableTemplate.content.push(JSON.parse(JSON.stringify(newItem)))
+    editableTemplate.draft.content.push(JSON.parse(JSON.stringify(newItem)))
   }
 
   const moveTemplateItem = (currentIndex: number, toIndex: number) => {
-    if (toIndex < 0 || toIndex >= editableTemplate.content.length || currentIndex === toIndex) {
+    if (toIndex < 0 || toIndex >= editableTemplate.draft.content.length || currentIndex === toIndex) {
       return
     }
-    const itemToMove = editableTemplate.content[currentIndex]
-    editableTemplate.content.splice(currentIndex, 1)
-    editableTemplate.content.splice(toIndex, 0, itemToMove)
+    const itemToMove = editableTemplate.draft.content[currentIndex]
+    editableTemplate.draft.content.splice(currentIndex, 1)
+    editableTemplate.draft.content.splice(toIndex, 0, itemToMove)
   }
 
   const removeTemplateItem = (index: number) => {
-    editableTemplate.content.splice(index, 1)
+    editableTemplate.draft.content.splice(index, 1)
   }
 
   const validateTemplate = (): boolean => {
@@ -122,7 +122,7 @@
 
     const { templateId } = await apiFetch(`/api/templates`, {
       method: "POST",
-      body: editableTemplate,
+      body: editableTemplate.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -143,9 +143,9 @@
       return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
-    await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
+    await apiFetch(`/api/templates/${editableTemplate.draft._id as NoSlashString}`, {
       method: "PUT",
-      body: editableTemplate,
+      body: editableTemplate.draft,
       headers: {
         "Content-Type": "application/json"
       }
@@ -166,7 +166,7 @@
       return { status: "cancelled" }
     }
 
-    await apiFetch(`/api/templates/${editableTemplate._id as NoSlashString}`, {
+    await apiFetch(`/api/templates/${editableTemplate.draft._id as NoSlashString}`, {
       method: "DELETE"
     })
 
@@ -183,14 +183,14 @@
       <label for="template-name" class="ds-label" data-weight="medium">
         Navn på notat-typen
       </label>
-      <input required id="template-name" class="ds-input" type="text" bind:value={editableTemplate.name} />
+      <input required id="template-name" class="ds-input" type="text" bind:value={editableTemplate.draft.name} />
     </ds-field>
 
     <ds-field class="ds-field">
       <label for="template-sort" class="ds-label" data-weight="medium">
         Sorteringsrekkefølge
       </label>
-      <input required id="template-sort" class="ds-input" type="number" bind:value={editableTemplate.sort} />
+      <input required id="template-sort" class="ds-input" type="number" bind:value={editableTemplate.draft.sort} />
     </ds-field>
 
     <div class="template-editor">
@@ -200,22 +200,22 @@
             Tilgjengelig som
           </legend>
           <ds-field class="ds-field">
-            <input class="ds-input" id="available-for-students" type="checkbox" bind:checked={editableTemplate.availableForDocumentType.student} />
+            <input class="ds-input" id="available-for-students" type="checkbox" bind:checked={editableTemplate.draft.availableForDocumentType.student} />
             <label class="ds-label" for="available-for-students">Elevnotat</label>
           </ds-field>
           <ds-field class="ds-field">
-            <input class="ds-input" id="available-for-groups" type="checkbox" bind:checked={editableTemplate.availableForDocumentType.group} />
+            <input class="ds-input" id="available-for-groups" type="checkbox" bind:checked={editableTemplate.draft.availableForDocumentType.group} />
             <label class="ds-label" for="available-for-groups">Klassenotat</label>
           </ds-field>
         </fieldset>
       </div>
 
       <div class="template-content">
-        {#if editableTemplate.content.length === 0}
+        {#if editableTemplate.draft.content.length === 0}
           <p>Ingen elementer i malen enda</p>
         {/if}
-        {#each editableTemplate.content as _contentItem, index}
-          <TemplateEditorItem bind:contentItem={editableTemplate.content[index]} index={index} contentItemsLength={editableTemplate.content.length} moveItem={toIndex => moveTemplateItem(index, toIndex)} removeItem={() => removeTemplateItem(index)} />
+        {#each editableTemplate.draft.content as _contentItem, index}
+          <TemplateEditorItem bind:contentItem={editableTemplate.draft.content[index]} index={index} contentItemsLength={editableTemplate.draft.content.length} moveItem={toIndex => moveTemplateItem(index, toIndex)} removeItem={() => removeTemplateItem(index)} />
         {/each}
       </div>
     </div>
@@ -232,7 +232,7 @@
 </div>
 
 <div class="template-preview" class:hidden={!previewMode}>
-  {#each editableTemplate.content as contentItem, index}
+  {#each editableTemplate.draft.content as contentItem, index}
     <DocumentContentItemComponent editMode={true} previewMode={true} {index} {contentItem} />
   {/each}
 </div>
@@ -243,15 +243,15 @@
   {#if previewMode}
     <button class="ds-button" data-variant="secondary" type="button" onclick={() => previewMode = false}><span class="material-symbols-outlined">edit</span>Rediger mal</button>
   {:else}
-    {#if !editableTemplate._id}
+    {#if !editableTemplate.draft._id}
       <AsyncButton buttonText="Lagre mal" onClick={newTemplate} iconName="save" />
     {:else}
-      <AsyncButton disabled={JSON.stringify(editableTemplate) === JSON.stringify(template)} buttonText="Lagre endringer" onClick={updateTemplate} iconName="save" />
+      <AsyncButton disabled={!editableTemplate.isDirty} buttonText="Lagre endringer" onClick={updateTemplate} iconName="save" />
     {/if}
     <button class="ds-button" data-variant="secondary" type="button" onclick={() => previewMode = true}><span class="material-symbols-outlined">visibility</span>Forhåndsvis mal</button>
   {/if}
   <a href="/system/templates" class="ds-button" data-variant="secondary"><span class="material-symbols-outlined">arrow_back</span>Tilbake til maler</a>
-  {#if editableTemplate._id}
+  {#if editableTemplate.draft._id}
     <AsyncButton buttonText="Slett mal" onClick={deleteTemplate} iconName="delete" color="danger" />
   {/if}
 </div>

--- a/src/lib/runes/create-editable-draft.svelte.test.ts
+++ b/src/lib/runes/create-editable-draft.svelte.test.ts
@@ -1,0 +1,363 @@
+import { flushSync } from "svelte"
+import { describe, expect, test } from "vitest"
+import { createEditableDraft } from "$lib/runes/create-editable-draft.svelte"
+
+const sourceStateData = {
+  name: "Alice",
+  age: 30,
+  address: {
+    city: "Oslo",
+    country: "Norway"
+  },
+  hobbies: [
+    {
+      name: "Reading",
+      books: [
+        { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+        { title: "To Kill a Mockingbird", author: "Harper Lee" }
+      ]
+    }
+  ]
+}
+
+type SourceStateData = typeof sourceStateData
+
+const getSourceDataFromState = (stateData: SourceStateData) => {
+  return {
+    name: stateData.name,
+    city: stateData.address.city,
+    hobbies: stateData.hobbies,
+    firstBookTitle: stateData.hobbies[0].books[0].title
+  }
+}
+
+describe("createEditable", () => {
+  test("should initialize with specific propeties from source value of deep nested object state", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      // Use flushSync to execute all pending effects synchronously
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Alice",
+        city: "Oslo",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+
+      expect(editableState.isDirty).toBe(false)
+    })
+
+    withEffect()
+  })
+
+  test("should only update draft editing draft, source should remain unchanged", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      // Use flushSync to execute all pending effects synchronously
+      flushSync()
+
+      editableState.draft.name = "Bob"
+      editableState.draft.city = "Bergen"
+      editableState.draft.hobbies[0].name = "Cooking"
+      editableState.draft.firstBookTitle = "1984"
+
+      // Also remove the first book from the hobbies to test that we are not mutating the original source when we edit the draft
+      editableState.draft.hobbies[0].books.shift()
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Bob",
+        city: "Bergen",
+        hobbies: [
+          {
+            name: "Cooking",
+            books: [{ title: "To Kill a Mockingbird", author: "Harper Lee" }]
+          }
+        ],
+        firstBookTitle: "1984"
+      })
+
+      expect(editableState.isDirty).toBe(true)
+      expect(sourceState.name).toBe("Alice")
+      expect(sourceState.address.city).toBe("Oslo")
+      expect(sourceState.hobbies[0].name).toBe("Reading")
+      expect(sourceState.hobbies[0].books[0].title).toBe("The Great Gatsby")
+    })
+
+    withEffect()
+  })
+
+  test("should set isDirty to true when draft is edited and back to false and source data when cancelled", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      // Use flushSync to execute all pending effects synchronously
+      flushSync()
+
+      editableState.draft.name = "Bob"
+      editableState.draft.city = "Bergen"
+      editableState.draft.hobbies[0].name = "Cooking"
+      editableState.draft.firstBookTitle = "1984"
+
+      // Also remove the first book from the hobbies to test that we are not mutating the original source when we edit the draft
+      editableState.draft.hobbies[0].books.shift()
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Bob",
+        city: "Bergen",
+        hobbies: [
+          {
+            name: "Cooking",
+            books: [{ title: "To Kill a Mockingbird", author: "Harper Lee" }]
+          }
+        ],
+        firstBookTitle: "1984"
+      })
+
+      expect(editableState.isDirty).toBe(true)
+
+      expect(sourceState.name).toBe("Alice")
+      expect(sourceState.address.city).toBe("Oslo")
+      expect(sourceState.hobbies[0].name).toBe("Reading")
+      expect(sourceState.hobbies[0].books[0].title).toBe("The Great Gatsby")
+
+      editableState.cancel()
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Alice",
+        city: "Oslo",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+
+      expect(sourceState.name).toBe("Alice")
+      expect(sourceState.address.city).toBe("Oslo")
+      expect(sourceState.hobbies[0].name).toBe("Reading")
+      expect(sourceState.hobbies[0].books[0].title).toBe("The Great Gatsby")
+
+      expect(editableState.isDirty).toBe(false)
+
+      // Verify draft is still a deep clone after cancel — mutating it must not affect source
+      editableState.draft.hobbies[0].books.shift()
+
+      flushSync()
+
+      expect(sourceState.hobbies[0].books.length).toBe(2)
+    })
+
+    withEffect()
+  })
+
+  test("should update draft to match source value when anything in source value changes", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      // Use flushSync to execute all pending effects synchronously
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Alice",
+        city: "Oslo",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+
+      // Now update the source state directly and test that the draft is updated to match the source value
+      sourceState.name = "Gunnar"
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Gunnar",
+        city: "Oslo",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+
+      // Make some edits to draft
+      editableState.draft.name = "Bob"
+      editableState.draft.city = "Bergen"
+      editableState.draft.hobbies[0].name = "Cooking"
+      editableState.draft.firstBookTitle = "1984"
+      // Also remove the first book from the hobbies to test that we are not mutating the original source when we edit the draft
+      editableState.draft.hobbies[0].books.shift()
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Bob",
+        city: "Bergen",
+        hobbies: [
+          {
+            name: "Cooking",
+            books: [{ title: "To Kill a Mockingbird", author: "Harper Lee" }]
+          }
+        ],
+        firstBookTitle: "1984"
+      })
+
+      expect(editableState.isDirty).toBe(true)
+
+      // Check that we still have 2 books in source state
+      expect(sourceState.hobbies[0].books.length).toBe(2)
+
+      // Now update the source state directly again and test that the draft is updated to match the source value and that we have 2 books in the draft again
+      sourceState.address.city = "Bergen"
+
+      flushSync()
+
+      expect(editableState.draft).toEqual({
+        name: "Gunnar",
+        city: "Bergen",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+
+      expect(editableState.isDirty).toBe(false)
+
+      expect(sourceState.name).toBe("Gunnar")
+      expect(sourceState.address.city).toBe("Bergen")
+      expect(sourceState.hobbies[0].name).toBe("Reading")
+      expect(sourceState.hobbies[0].books[0].title).toBe("The Great Gatsby")
+      expect(sourceState.hobbies[0].books.length).toBe(2)
+    })
+
+    withEffect()
+  })
+
+  test("should leave draft unchanged and isDirty false when cancel is called while not dirty", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      flushSync()
+
+      expect(editableState.isDirty).toBe(false)
+
+      editableState.cancel()
+
+      flushSync()
+
+      expect(editableState.isDirty).toBe(false)
+      expect(editableState.draft).toEqual({
+        name: "Alice",
+        city: "Oslo",
+        hobbies: [
+          {
+            name: "Reading",
+            books: [
+              { title: "The Great Gatsby", author: "F. Scott Fitzgerald" },
+              { title: "To Kill a Mockingbird", author: "Harper Lee" }
+            ]
+          }
+        ],
+        firstBookTitle: "The Great Gatsby"
+      })
+    })
+
+    withEffect()
+  })
+
+  test("should cancel to current source value, not original, when source has changed since initialization", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      flushSync()
+
+      sourceState.name = "Gunnar"
+      sourceState.address.city = "Bergen"
+
+      flushSync()
+
+      expect(editableState.draft.name).toBe("Gunnar")
+      expect(editableState.draft.city).toBe("Bergen")
+
+      editableState.draft.name = "Bob"
+      editableState.draft.city = "Stavanger"
+
+      flushSync()
+
+      expect(editableState.isDirty).toBe(true)
+
+      editableState.cancel()
+
+      flushSync()
+
+      expect(editableState.isDirty).toBe(false)
+      expect(editableState.draft.name).toBe("Gunnar")
+      expect(editableState.draft.city).toBe("Bergen")
+    })
+
+    withEffect()
+  })
+
+  test("should not set isDirty when a draft field is set to its current value", () => {
+    const withEffect = $effect.root(() => {
+      const sourceState = $state(sourceStateData)
+      const editableState = createEditableDraft(() => getSourceDataFromState(sourceState))
+
+      flushSync()
+
+      editableState.draft.name = "Alice"
+
+      flushSync()
+
+      expect(editableState.isDirty).toBe(false)
+    })
+
+    withEffect()
+  })
+})

--- a/src/lib/runes/create-editable-draft.svelte.ts
+++ b/src/lib/runes/create-editable-draft.svelte.ts
@@ -1,0 +1,63 @@
+import { untrack } from "svelte"
+
+/**
+ * The reactive object returned by `createEditableDraft`.
+ */
+export type EditableDraft<T> = {
+  /** Reactive `$state` clone of the source. Mutate directly or use `bind:value` — changes do not affect the original. */
+  draft: T
+  /** `true` when `draft` differs from the current source value (compared by JSON serialisation). */
+  isDirty: boolean
+  /** Resets `draft` back to the current source value, discarding all unsaved edits. */
+  cancel(): void
+}
+
+/**
+ * Creates a reactive editing draft from a source value.
+ *
+ * The returned `draft` is a deep-cloned, mutable copy of the source. Mutating
+ * it does not affect the original. When the source changes externally the draft
+ * is automatically reset to the new source value. Call `cancel()` at any time
+ * to discard local edits and snap back to the source.
+ *
+ * Must be called in a Svelte component or rune context (uses `$state`, `$derived`, `$effect`).
+ *
+ * @param getSource Reactive getter returning the source value. Pass a lambda so
+ *   runes can track reactivity: `() => someReactiveValue`.
+ * @returns Object with `draft` (editable clone), `isDirty` (change flag), and `cancel()`.
+ *
+ * @example
+ * // In a .svelte component:
+ * // const editable = createEditableDraft(() => user);
+ * // `editable.draft` is reactive state — use bind:value directly:
+ * //   <input bind:value={editable.draft.name} />
+ * // Check editable.isDirty to show save/cancel controls; call editable.cancel() to revert.
+ */
+export const createEditableDraft = <T>(getSource: () => T) => {
+  const getClonedSource = () => $state.snapshot(getSource())
+
+  let draft = $state({ value: getClonedSource() })
+
+  let isDirty = $derived.by(() => {
+    return JSON.stringify(draft.value) !== JSON.stringify(getSource())
+  })
+
+  $effect(() => {
+    const latestClonedSource = getClonedSource()
+    untrack(() => {
+      draft.value = latestClonedSource
+    })
+  })
+
+  return {
+    get draft() {
+      return draft.value as T
+    },
+    get isDirty() {
+      return isDirty
+    },
+    cancel() {
+      draft.value = getClonedSource()
+    }
+  } satisfies EditableDraft<T>
+}

--- a/src/lib/runes/create-editable-draft.svelte.ts
+++ b/src/lib/runes/create-editable-draft.svelte.ts
@@ -45,13 +45,18 @@ export const createEditableDraft = <T>(getSource: () => T) => {
   $effect(() => {
     const latestClonedSource = getClonedSource()
     untrack(() => {
-      draft.value = latestClonedSource
+      if (JSON.stringify(draft.value) !== JSON.stringify(latestClonedSource)) {
+        draft.value = latestClonedSource
+      }
     })
   })
 
   return {
     get draft() {
       return draft.value as T
+    },
+    set draft(newDraft: T) {
+      draft.value = newDraft as ReturnType<typeof getClonedSource>
     },
     get isDirty() {
       return isDirty

--- a/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
+++ b/src/routes/schooladministration/[schoolnumber]/manualstudents/[studentId]/+page.svelte
@@ -5,6 +5,7 @@
   import PageHeader from "$lib/components/PageHeader.svelte"
   import { nameValidation, ssnValidation } from "$lib/data-validation/manual-student-validation"
   import { INVALID_FORM_MESSAGE } from "$lib/data-validation/validation-constants"
+  import { createEditableDraft } from "$lib/runes/create-editable-draft.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map"
   import type { UpdateManualStudentInput } from "$lib/types/db/shared-types"
   import type { PageProps } from "./$types"
@@ -26,27 +27,32 @@
 
   let updateManualStudentEdit: boolean = $state(false)
   let updateManualStudentForm: HTMLFormElement | undefined = $state()
-  let updateManualStudentFnr: string = $derived.by(() => data.manualStudent.ssn)
-  let updateManualStudentName: string = $derived.by(() => data.manualStudent.name)
-  let updateManualStudentHasBlockedAddress: boolean = $derived.by(() => data.manualStudent.hasBlockedAddress ?? false)
+
+  let manualStudentSource = $derived.by(() => ({
+    ssn: data.manualStudent.ssn,
+    name: data.manualStudent.name,
+    hasBlockedAddress: data.manualStudent.hasBlockedAddress ?? false
+  }))
+
+  let editableManualStudent = createEditableDraft(() => manualStudentSource)
 
   const updateManualStudent = async (): Promise<AsyncButtonResult> => {
     if (!updateManualStudentForm?.reportValidity()) {
       return { status: "error", message: INVALID_FORM_MESSAGE }
     }
 
-    if (!updateManualStudentFnr) {
+    if (!editableManualStudent.draft.ssn) {
       return { status: "error", message: "Fødselsnummer må være fylt ut" }
     }
 
-    if (!updateManualStudentName) {
+    if (!editableManualStudent.draft.name) {
       return { status: "error", message: "Navn må være fylt ut" }
     }
 
     const updateManualStudentInput: UpdateManualStudentInput = {
-      ssn: updateManualStudentFnr,
-      name: updateManualStudentName,
-      hasBlockedAddress: updateManualStudentHasBlockedAddress,
+      ssn: editableManualStudent.draft.ssn,
+      name: editableManualStudent.draft.name,
+      hasBlockedAddress: editableManualStudent.draft.hasBlockedAddress,
       school: currentSchool,
       studentId: data.manualStudent._id
     }
@@ -70,17 +76,7 @@
 
   const abortUpdateManualStudent = () => {
     updateManualStudentEdit = false
-    updateManualStudentFnr = data.manualStudent.ssn
-    updateManualStudentName = data.manualStudent.name
-    updateManualStudentHasBlockedAddress = data.manualStudent.hasBlockedAddress ?? false
-  }
-
-  const isDisabled = (): boolean => {
-    return (
-      updateManualStudentFnr === data.manualStudent.ssn &&
-      updateManualStudentName === data.manualStudent.name &&
-      updateManualStudentHasBlockedAddress === (data.manualStudent.hasBlockedAddress ?? false)
-    )
+    editableManualStudent.cancel()
   }
 </script>
 
@@ -98,11 +94,11 @@
     <div class="update-manual-student">
       <div>
         <h2 class="ds-heading">Fødselsnummer</h2>
-        <p class="ds-paragraph">{updateManualStudentFnr}</p>
+        <p class="ds-paragraph">{data.manualStudent.ssn}</p>
       </div>
       <div>
         <h2 class="ds-heading">Adressesperre</h2>
-        <p class="ds-paragraph">{updateManualStudentHasBlockedAddress ? "Ja" : "Nei"}</p>
+        <p class="ds-paragraph">{(data.manualStudent.hasBlockedAddress ?? false) ? "Ja" : "Nei"}</p>
       </div>
       <div>
         <button onclick={() => updateManualStudentEdit = true} class="ds-button">
@@ -120,7 +116,7 @@
             <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
           </label>
           <div class="ds-field-affixes">
-            <input class="ds-input" inputmode="numeric" type="text" id="fnr" pattern={ssnValidation.pattern.source} minlength={ssnValidation.minLength} maxlength={ssnValidation.maxLength} bind:value={updateManualStudentFnr} required>
+            <input class="ds-input" inputmode="numeric" type="text" id="fnr" pattern={ssnValidation.pattern.source} minlength={ssnValidation.minLength} maxlength={ssnValidation.maxLength} bind:value={editableManualStudent.draft.ssn} required>
           </div>
         </ds-field>
 
@@ -130,18 +126,18 @@
             <span class="ds-tag" data-variant="outline" data-size="sm" data-color="warning" style="margin-inline-start:var(--ds-size-2)">Må fylles ut</span>
           </label>
           <div class="ds-field-affixes">
-            <input class="ds-input" type="text" id="name" pattern={nameValidation.pattern.source} minlength={nameValidation.minLength} maxlength={nameValidation.maxLength} bind:value={updateManualStudentName} required>
+            <input class="ds-input" type="text" id="name" pattern={nameValidation.pattern.source} minlength={nameValidation.minLength} maxlength={nameValidation.maxLength} bind:value={editableManualStudent.draft.name} required>
           </div>
         </ds-field>
 
         <ds-field class="ds-field content-item">
           <label class="ds-label" data-weight="medium" for="blockedAddress" data-clickdelegatefor="blockedAddress">Adressesperre</label>
-          <input class="ds-input" type="checkbox" id="blockedAddress" bind:checked={updateManualStudentHasBlockedAddress}>
+          <input class="ds-input" type="checkbox" id="blockedAddress" bind:checked={editableManualStudent.draft.hasBlockedAddress}>
         </ds-field>
       </form>
 
       <div class="manual-student-save-actions">
-        <AsyncButton onClick={updateManualStudent} buttonText="Lagre" iconName="save" disabled={isDisabled()} />
+        <AsyncButton onClick={updateManualStudent} buttonText="Lagre" iconName="save" disabled={!editableManualStudent.isDirty} />
         <button class="ds-button" type="button" data-variant="secondary" onclick={abortUpdateManualStudent}><span class="material-symbols-outlined">close</span>Avbryt</button>
       </div>
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,30 @@
 import { sveltekit } from "@sveltejs/kit/vite"
-import { defineConfig } from "vite"
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
-  plugins: [sveltekit()]
+  plugins: [sveltekit()],
+  test: {
+    projects: [
+      {
+        extends: "./vite.config.ts",
+        mode: "vitest-client",
+        test: {
+          name: "client",
+          environment: "happy-dom",
+          include: ["src/**/*.svelte.{test,spec}.{js,ts}"],
+          exclude: ["src/lib/server/**", "tests/server/**"]
+        },
+        resolve: { conditions: ["browser"] }
+      },
+      {
+        extends: "./vite.config.ts",
+        mode: "vitest-server",
+        test: {
+          name: "server",
+          environment: "node",
+          include: ["tests/server/**/*.{test,spec}.{js,ts}"]
+        }
+      }
+    ]
+  }
 })


### PR DESCRIPTION
### Minor commits:
- feat: added createEditableDraft custom rune (5abfa58)
- feat: added vite testing config (6cde62c)

### Patch commits:
- fix: refactor DataSharingConsent component to use createEditableDraft for state management (3f42928)

### Maintenance commits:
- refactor: optimize draft value assignment in createEditableDraft to prevent unnecessary updates (3153986)
- chore: lint:fix (ca7be30)
- refactor: update StudentCheckBox component to streamline editableCheckBox initialization (202004e)
- refactor: enhance StudentCheckBox component to utilize createEditableDraft for improved state management (c7cdf55)
- refactor: simplify manual student update logic using createEditableDraft for improved state management (c9644f9)
- refactor: streamline state management in ImportantGroupStuff component using createEditableDraft (b0b07a8)
- refactor: update TemplateEditor component to utilize createEditableDraft for improved state management (cdcf590)
- refactor: update ProgramArea component to use createEditableDraft for improved state management (a61c2b1)
- refactor: integrate createEditableDraft for message handling and improve state management (104f765)
- refactor: enhance document creation validation using derived state (83607a7)
- refactor: use createEditableDraft for document state management (bcf120e)
- refactor: update ImportantStuff component to use createEditableDraft for improved state management (667f47b)
