### PR TITLE
minor: 1.0.0 - feat-student-document-filter

### DIFF
--- a/src/lib/server/db/mock/mock-db-client.ts
+++ b/src/lib/server/db/mock/mock-db-client.ts
@@ -42,6 +42,8 @@ export const mockDbClient: IDbClient = {
   documents: {
     getStudentDocuments: notImplemented,
     getStudentDocumentById: notImplemented,
+    getStudentIdsWithoutDocuments: notImplemented,
+    getStudentIdsWithDocumentForTemplates: notImplemented,
     createStudentDocument: notImplemented,
     updateStudentDocument: notImplemented,
     deleteStudentDocument: notImplemented,

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -31,6 +31,14 @@ if (!documentLockStart) {
   logger.warn("Document locking is enabled. Documents will be locked at school year end, currently set to {DocumentLockStart} (MM-DD)", documentLockStart)
 }
 
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size))
+  }
+  return chunks
+}
+
 function buildStudentAccessCondition({ studentId, schoolNumbers, subjectTeacherOnlySchoolNumbers, hasDataSharingConsent, principalEntraUserId }: StudentDocumentAccess): Filter<DbStudentDocument> {
   const id = new ObjectId(studentId)
 
@@ -141,12 +149,13 @@ export class DocumentsDbClient implements IDocumentsDbClient {
 
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
-    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", {
-      $or: studentAccess.map((access) => buildStudentAccessCondition(access))
-    })
+    const chunks = chunkArray(studentAccess, 500)
+    const results = await Promise.all(
+      chunks.map((chunk) => documentsCollection.distinct("student._id", { $or: chunk.map(buildStudentAccessCondition) }))
+    )
 
-    const studentIdsWithDocumentsSet = new Set(studentIdsWithDocuments.map((id) => id.toString()))
-    return studentAccess.filter(({ studentId }) => !studentIdsWithDocumentsSet.has(studentId)).map(({ studentId }) => studentId)
+    const studentIdsWithDocuments = new Set(results.flat().map((id) => id.toString()))
+    return studentAccess.filter(({ studentId }) => !studentIdsWithDocuments.has(studentId)).map(({ studentId }) => studentId)
   }
 
   async getStudentIdsWithDocumentForTemplates(studentAccess: StudentDocumentAccess[], templateIds: string[]): Promise<string[]> {
@@ -157,12 +166,17 @@ export class DocumentsDbClient implements IDocumentsDbClient {
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
     const templateObjectIds = templateIds.map((id) => new ObjectId(id))
-    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", {
-      "template._id": { $in: templateObjectIds },
-      $or: studentAccess.map((access) => buildStudentAccessCondition(access))
-    })
+    const chunks = chunkArray(studentAccess, 500)
+    const results = await Promise.all(
+      chunks.map((chunk) =>
+        documentsCollection.distinct("student._id", {
+          "template._id": { $in: templateObjectIds },
+          $or: chunk.map(buildStudentAccessCondition)
+        })
+      )
+    )
 
-    return studentIdsWithDocuments.map((id) => id.toString())
+    return [...new Set(results.flat().map((id) => id.toString()))]
   }
 
   async getStudentDocumentById(documentId: string): Promise<StudentDocument | null> {

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -103,6 +103,29 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       .sort((a: StudentDocument, b: StudentDocument) => b.created.at.getTime() - a.created.at.getTime()) // Sort by created date descending
   }
 
+  async getStudentIdsWithoutDocuments(studentIds: string[]): Promise<string[]> {
+    const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
+
+    const objectIds = studentIds.map((id) => new ObjectId(id))
+    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", { "student._id": { $in: objectIds } })
+    const studentIdsWithDocumentsSet = new Set(studentIdsWithDocuments.map((id) => id.toString()))
+
+    return studentIds.filter((id) => !studentIdsWithDocumentsSet.has(id))
+  }
+
+  async getStudentIdsWithDocumentForTemplates(studentIds: string[], templateIds: string[]): Promise<string[]> {
+    const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
+
+    const studentObjectIds = studentIds.map((id) => new ObjectId(id))
+    const templateObjectIds = templateIds.map((id) => new ObjectId(id))
+    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", {
+      "student._id": { $in: studentObjectIds },
+      "template._id": { $in: templateObjectIds }
+    })
+
+    return studentIdsWithDocuments.map((id) => id.toString())
+  }
+
   async getStudentDocumentById(documentId: string): Promise<StudentDocument | null> {
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -91,6 +91,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
         const studentDocument: StudentDocument = {
           ...document,
           student: { _id: document.student._id.toString() },
+          template: { _id: document.template._id.toString(), name: document.template.name, version: document.template.version },
           _id: document._id.toString(),
           isDocumentLocked: this.isDocumentLocked(document.created.at)
         }
@@ -114,6 +115,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
     return {
       ...document,
       student: { _id: document.student._id.toString() },
+      template: { _id: document.template._id.toString(), name: document.template.name, version: document.template.version },
       _id: document._id.toString(),
       isDocumentLocked: this.isDocumentLocked(document.created.at)
     }
@@ -128,7 +130,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       content: await this.encryptValue(document.content),
       title: await this.encryptValue(document.title),
       template: {
-        _id: document.template._id,
+        _id: new ObjectId(document.template._id),
         name: await this.encryptValue(document.template.name),
         version: document.template.version
       },
@@ -168,7 +170,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       content: await this.encryptValue(documentUpdate.content),
       title: await this.encryptValue(documentUpdate.title),
       template: {
-        _id: documentUpdate.template._id,
+        _id: new ObjectId(documentUpdate.template._id),
         name: await this.encryptValue(documentUpdate.template.name),
         version: documentUpdate.template.version
       }
@@ -336,7 +338,16 @@ export class DocumentsDbClient implements IDocumentsDbClient {
         delete document.tyler_the_creator
 
         const groupDocument: GroupDocument = {
-          ...document,
+          created: document.created,
+          modified: document.modified,
+          school: document.school,
+          title: document.title,
+          template: { _id: document.template._id.toString(), name: document.template.name, version: document.template.version },
+          content: document.content,
+          documentAccess: document.documentAccess,
+          emailAlertReceivers: document.emailAlertReceivers,
+          messages: document.messages,
+          group: document.group,
           _id: document._id.toString(),
           isDocumentLocked: this.isDocumentLocked(document.created.at)
         }
@@ -360,7 +371,16 @@ export class DocumentsDbClient implements IDocumentsDbClient {
     }
 
     return {
-      ...document,
+      created: document.created,
+      modified: document.modified,
+      school: document.school,
+      title: document.title,
+      template: { _id: document.template._id.toString(), name: document.template.name, version: document.template.version },
+      content: document.content,
+      documentAccess: document.documentAccess,
+      emailAlertReceivers: document.emailAlertReceivers,
+      messages: document.messages,
+      group: document.group,
       _id: document._id.toString(),
       isDocumentLocked: this.isDocumentLocked(document.created.at)
     }
@@ -384,7 +404,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       content: await this.encryptValue(document.content),
       title: await this.encryptValue(document.title),
       template: {
-        _id: document.template._id,
+        _id: new ObjectId(document.template._id),
         name: await this.encryptValue(document.template.name),
         version: document.template.version
       },
@@ -424,7 +444,7 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       content: await this.encryptValue(documentUpdate.content),
       title: await this.encryptValue(documentUpdate.title),
       template: {
-        _id: documentUpdate.template._id,
+        _id: new ObjectId(documentUpdate.template._id),
         name: await this.encryptValue(documentUpdate.template.name),
         version: documentUpdate.template.version
       }

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -1,7 +1,7 @@
 import { logger } from "@vestfoldfylke/loglady"
-import { type Binary, type Db, type DeleteResult, ObjectId } from "mongodb"
+import { type Binary, type Db, type DeleteResult, type Filter, ObjectId } from "mongodb"
 import { env } from "$env/dynamic/private"
-import type { IDocumentsDbClient } from "$lib/types/db/db-client"
+import type { IDocumentsDbClient, StudentDocumentAccess } from "$lib/types/db/db-client"
 import type {
   DbEncryptedDocumentMessage,
   DbEncryptedGroupDocument,
@@ -29,6 +29,37 @@ if (!documentLockStart) {
   logger.warn("DOCUMENT_LOCK_START_MM_DD environment variable is not set. Document locking is disabled.")
 } else {
   logger.warn("Document locking is enabled. Documents will be locked at school year end, currently set to {DocumentLockStart} (MM-DD)", documentLockStart)
+}
+
+function buildStudentAccessCondition({ studentId, schoolNumbers, subjectTeacherOnlySchoolNumbers, hasDataSharingConsent, principalEntraUserId }: StudentDocumentAccess): Filter<DbStudentDocument> {
+  const id = new ObjectId(studentId)
+
+  if (subjectTeacherOnlySchoolNumbers.length === 0) {
+    if (hasDataSharingConsent) {
+      return { "student._id": id }
+    }
+    return { "student._id": id, "school.schoolNumber": { $in: schoolNumbers } }
+  }
+
+  const subjectTeacherOnlySet = new Set(subjectTeacherOnlySchoolNumbers)
+  const fullAccessSchools = schoolNumbers.filter((s) => !subjectTeacherOnlySet.has(s))
+
+  // At subject-teacher-only schools: visible if access is granted to all, OR the principal created the document themselves
+  const subjectTeacherClause = {
+    "school.schoolNumber": { $in: subjectTeacherOnlySchoolNumbers },
+    $or: [{ documentAccess: "ALL_WITH_STUDENT_ACCESS" as const }, { "created.by.entraUserId": principalEntraUserId }]
+  }
+
+  if (hasDataSharingConsent) {
+    return {
+      "student._id": id,
+      $or: [{ "school.schoolNumber": { $nin: subjectTeacherOnlySchoolNumbers } }, subjectTeacherClause]
+    }
+  }
+
+  const orClauses = fullAccessSchools.length > 0 ? [{ "school.schoolNumber": { $in: fullAccessSchools } }, subjectTeacherClause] : [subjectTeacherClause]
+
+  return { "student._id": id, $or: orClauses }
 }
 
 export class DocumentsDbClient implements IDocumentsDbClient {
@@ -103,24 +134,32 @@ export class DocumentsDbClient implements IDocumentsDbClient {
       .sort((a: StudentDocument, b: StudentDocument) => b.created.at.getTime() - a.created.at.getTime()) // Sort by created date descending
   }
 
-  async getStudentIdsWithoutDocuments(studentIds: string[]): Promise<string[]> {
+  async getStudentIdsWithoutDocuments(studentAccess: StudentDocumentAccess[]): Promise<string[]> {
+    if (studentAccess.length === 0) {
+      return []
+    }
+
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
-    const objectIds = studentIds.map((id) => new ObjectId(id))
-    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", { "student._id": { $in: objectIds } })
-    const studentIdsWithDocumentsSet = new Set(studentIdsWithDocuments.map((id) => id.toString()))
+    const studentIdsWithDocuments = await documentsCollection.distinct("student._id", {
+      $or: studentAccess.map((access) => buildStudentAccessCondition(access))
+    })
 
-    return studentIds.filter((id) => !studentIdsWithDocumentsSet.has(id))
+    const studentIdsWithDocumentsSet = new Set(studentIdsWithDocuments.map((id) => id.toString()))
+    return studentAccess.filter(({ studentId }) => !studentIdsWithDocumentsSet.has(studentId)).map(({ studentId }) => studentId)
   }
 
-  async getStudentIdsWithDocumentForTemplates(studentIds: string[], templateIds: string[]): Promise<string[]> {
+  async getStudentIdsWithDocumentForTemplates(studentAccess: StudentDocumentAccess[], templateIds: string[]): Promise<string[]> {
+    if (studentAccess.length === 0) {
+      return []
+    }
+
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
-    const studentObjectIds = studentIds.map((id) => new ObjectId(id))
     const templateObjectIds = templateIds.map((id) => new ObjectId(id))
     const studentIdsWithDocuments = await documentsCollection.distinct("student._id", {
-      "student._id": { $in: studentObjectIds },
-      "template._id": { $in: templateObjectIds }
+      "template._id": { $in: templateObjectIds },
+      $or: studentAccess.map((access) => buildStudentAccessCondition(access))
     })
 
     return studentIdsWithDocuments.map((id) => id.toString())

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -31,7 +31,7 @@ if (!documentLockStart) {
   logger.warn("Document locking is enabled. Documents will be locked at school year end, currently set to {DocumentLockStart} (MM-DD)", documentLockStart)
 }
 
-const CHUNK_SIZE = 5000
+const CHUNK_SIZE = 5000 // Only a security guard if someone suddenly has access to 10 000s of students, to avoid creating too large queries for MongoDB which can cause it to be really slow.
 
 function chunkArray<T>(arr: T[], size: number): T[][] {
   const chunks: T[][] = []

--- a/src/lib/server/db/mongo/documents-db-client.ts
+++ b/src/lib/server/db/mongo/documents-db-client.ts
@@ -31,6 +31,8 @@ if (!documentLockStart) {
   logger.warn("Document locking is enabled. Documents will be locked at school year end, currently set to {DocumentLockStart} (MM-DD)", documentLockStart)
 }
 
+const CHUNK_SIZE = 5000
+
 function chunkArray<T>(arr: T[], size: number): T[][] {
   const chunks: T[][] = []
   for (let i = 0; i < arr.length; i += size) {
@@ -53,9 +55,9 @@ function buildStudentAccessCondition({ studentId, schoolNumbers, subjectTeacherO
   const fullAccessSchools = schoolNumbers.filter((s) => !subjectTeacherOnlySet.has(s))
 
   // At subject-teacher-only schools: visible if access is granted to all, OR the principal created the document themselves
-  const subjectTeacherClause = {
+  const subjectTeacherClause: Filter<DbStudentDocument> = {
     "school.schoolNumber": { $in: subjectTeacherOnlySchoolNumbers },
-    $or: [{ documentAccess: "ALL_WITH_STUDENT_ACCESS" as const }, { "created.by.entraUserId": principalEntraUserId }]
+    $or: [{ documentAccess: "ALL_WITH_STUDENT_ACCESS" }, { "created.by.entraUserId": principalEntraUserId }]
   }
 
   if (hasDataSharingConsent) {
@@ -149,10 +151,8 @@ export class DocumentsDbClient implements IDocumentsDbClient {
 
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
-    const chunks = chunkArray(studentAccess, 500)
-    const results = await Promise.all(
-      chunks.map((chunk) => documentsCollection.distinct("student._id", { $or: chunk.map(buildStudentAccessCondition) }))
-    )
+    const chunks = chunkArray(studentAccess, CHUNK_SIZE)
+    const results = await Promise.all(chunks.map((chunk) => documentsCollection.distinct("student._id", { $or: chunk.map(buildStudentAccessCondition) })))
 
     const studentIdsWithDocuments = new Set(results.flat().map((id) => id.toString()))
     return studentAccess.filter(({ studentId }) => !studentIdsWithDocuments.has(studentId)).map(({ studentId }) => studentId)
@@ -165,18 +165,32 @@ export class DocumentsDbClient implements IDocumentsDbClient {
 
     const documentsCollection = this.encryptionDb.collection<DbStudentDocument>(this.documentsCollectionName)
 
-    const templateObjectIds = templateIds.map((id) => new ObjectId(id))
-    const chunks = chunkArray(studentAccess, 500)
-    const results = await Promise.all(
-      chunks.map((chunk) =>
-        documentsCollection.distinct("student._id", {
-          "template._id": { $in: templateObjectIds },
-          $or: chunk.map(buildStudentAccessCondition)
-        })
-      )
+    const chunks = chunkArray(studentAccess, CHUNK_SIZE)
+
+    const setsPerTemplate = await Promise.all(
+      templateIds.map(async (templateId) => {
+        const results = await Promise.all(
+          chunks.map((chunk) =>
+            documentsCollection.distinct("student._id", {
+              "template._id": new ObjectId(templateId),
+              $or: chunk.map(buildStudentAccessCondition)
+            })
+          )
+        )
+        return new Set(results.flat().map((id) => id.toString()))
+      })
     )
 
-    return [...new Set(results.flat().map((id) => id.toString()))]
+    const [first, ...rest] = setsPerTemplate
+    const intersection = rest.reduce((acc, set) => {
+      for (const id of acc) {
+        if (!set.has(id)) {
+          acc.delete(id)
+        }
+      }
+      return acc
+    }, first)
+    return [...(intersection ?? [])]
   }
 
   async getStudentDocumentById(documentId: string): Promise<StudentDocument | null> {

--- a/src/lib/server/get-frontend-overview-students.ts
+++ b/src/lib/server/get-frontend-overview-students.ts
@@ -94,17 +94,41 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
   }
 
   const timeTaken = Date.now() - now
-  logger.debug(`Finished filtering students and adding important stuff. Time taken: {TimeTaken} ms. Returning {OverviewStudentCount} overview students`, timeTaken, overviewStudents.length)
+  logger.debug(`Finished filtering students and adding important stuff. Time taken: {TimeTaken} ms.`, timeTaken)
 
-  const studentReturnLength = studentFilter?.top ?? overviewStudents.length
+  const timeBeforeDocumentFiltering = Date.now()
+
+  // Apply document filters
+  let documentFilteredStudents = overviewStudents
+
+  if (Array.isArray(studentFilter?.templateIds) && studentFilter.templateIds.length > 0) {
+    logger.info("Filtering students by templateIds: {TemplateIds}", studentFilter.templateIds)
+    const candidateIds = overviewStudents.map((s) => s._id)
+    const matchingIds = new Set(await dbClient.documents.getStudentIdsWithDocumentForTemplates(candidateIds, studentFilter.templateIds))
+    documentFilteredStudents = overviewStudents.filter((s) => matchingIds.has(s._id))
+    logger.info("After templateIds filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
+  }
+
+  if (studentFilter?.hasNoDocuments === true) {
+    logger.info("Filtering students to those without any documents")
+    const candidateIds = documentFilteredStudents.map((s) => s._id)
+    const idsWithoutDocuments = new Set(await dbClient.documents.getStudentIdsWithoutDocuments(candidateIds))
+    documentFilteredStudents = documentFilteredStudents.filter((s) => idsWithoutDocuments.has(s._id))
+    logger.info("After hasNoDocuments filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
+  }
+
+  const documentFilteringTimeTaken = Date.now() - timeBeforeDocumentFiltering
+  logger.debug(`Finished applying document filters. Time taken: {TimeTaken} ms. Returning {FilteredCount} of {TotalCount} students`, documentFilteringTimeTaken, documentFilteredStudents.length, overviewStudents.length)
+
+  const studentReturnLength = studentFilter?.top ?? documentFilteredStudents.length
 
   logger.info(
     `Finished filtering students and adding important stuff. Returning {OverviewStudentCount} overview students capped to {OverviewStudentCountCapped}`,
-    overviewStudents.length,
+    documentFilteredStudents.length,
     studentReturnLength
   )
 
-  const students = overviewStudents
+  const students = documentFilteredStudents
     .sort((a, b) => {
       const sortBy = studentFilter?.sortBy || "studentName"
       const sortDirection = studentFilter?.sortDirection === "descending" ? -1 : 1

--- a/src/lib/server/get-frontend-overview-students.ts
+++ b/src/lib/server/get-frontend-overview-students.ts
@@ -122,6 +122,10 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
 
   const timeBeforeDocumentFiltering = Date.now()
 
+  if (studentFilter?.hasNoDocuments && studentFilter.templateIds && studentFilter.templateIds.length > 0) {
+    throw new HTTPError(400, "hasNoDocuments and templateIds filters cannot be combined")
+  }
+
   // Apply document filters
   let documentFilteredStudents = overviewStudents
 

--- a/src/lib/server/get-frontend-overview-students.ts
+++ b/src/lib/server/get-frontend-overview-students.ts
@@ -1,10 +1,34 @@
 import { logger } from "@vestfoldfylke/loglady"
 import type { FrontendOverviewStudent, FrontendOverviewStudentFilter, FrontendOverviewStudentResponse, PrincipalAccess } from "$lib/types/app-types"
-import type { IDbClient } from "$lib/types/db/db-client"
+import type { IDbClient, StudentDocumentAccess } from "$lib/types/db/db-client"
 import type { StudentDataSharingConsent, StudentImportantStuff } from "$lib/types/db/shared-types"
+import { SUBJECT_TEACHER_ACCESS_TYPES } from "$lib/utils/access-constants"
 import { getStudentsFromCache } from "./cache/students-cache"
 import { getDbClient } from "./db/get-db-client"
 import { HTTPError } from "./middleware/http-error"
+
+function buildStudentDocumentAccess(students: FrontendOverviewStudent[], principalEntraUserId: string): StudentDocumentAccess[] {
+  return students.map((s) => {
+    const schoolAccessTypes = new Map<string, Set<string>>()
+    for (const a of s.principalAccessForStudent) {
+      const existing = schoolAccessTypes.get(a.schoolNumber) ?? new Set<string>()
+      existing.add(a.type)
+      schoolAccessTypes.set(a.schoolNumber, existing)
+    }
+
+    const subjectTeacherOnlySchoolNumbers = [...schoolAccessTypes.entries()]
+      .filter(([, types]) => [...types].every((type) => (SUBJECT_TEACHER_ACCESS_TYPES as readonly string[]).includes(type)))
+      .map(([schoolNumber]) => schoolNumber)
+
+    return {
+      studentId: s._id,
+      schoolNumbers: [...new Set(s.principalAccessForStudent.map((a) => a.schoolNumber))],
+      subjectTeacherOnlySchoolNumbers,
+      hasDataSharingConsent: s.dataSharingConsent,
+      principalEntraUserId
+    }
+  })
+}
 
 export const getFrontendOverviewStudents = async (principalAccess: PrincipalAccess, studentFilter?: FrontendOverviewStudentFilter): Promise<FrontendOverviewStudentResponse> => {
   logger.info("Fetching students for principal")
@@ -103,22 +127,27 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
 
   if (Array.isArray(studentFilter?.templateIds) && studentFilter.templateIds.length > 0) {
     logger.info("Filtering students by templateIds: {TemplateIds}", studentFilter.templateIds)
-    const candidateIds = overviewStudents.map((s) => s._id)
-    const matchingIds = new Set(await dbClient.documents.getStudentIdsWithDocumentForTemplates(candidateIds, studentFilter.templateIds))
+    const studentAccess = buildStudentDocumentAccess(overviewStudents, principalAccess.entraUserId)
+    const matchingIds = new Set(await dbClient.documents.getStudentIdsWithDocumentForTemplates(studentAccess, studentFilter.templateIds))
     documentFilteredStudents = overviewStudents.filter((s) => matchingIds.has(s._id))
     logger.info("After templateIds filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
   }
 
   if (studentFilter?.hasNoDocuments === true) {
     logger.info("Filtering students to those without any documents")
-    const candidateIds = documentFilteredStudents.map((s) => s._id)
-    const idsWithoutDocuments = new Set(await dbClient.documents.getStudentIdsWithoutDocuments(candidateIds))
+    const studentAccess = buildStudentDocumentAccess(documentFilteredStudents, principalAccess.entraUserId)
+    const idsWithoutDocuments = new Set(await dbClient.documents.getStudentIdsWithoutDocuments(studentAccess))
     documentFilteredStudents = documentFilteredStudents.filter((s) => idsWithoutDocuments.has(s._id))
     logger.info("After hasNoDocuments filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
   }
 
   const documentFilteringTimeTaken = Date.now() - timeBeforeDocumentFiltering
-  logger.debug(`Finished applying document filters. Time taken: {TimeTaken} ms. Returning {FilteredCount} of {TotalCount} students`, documentFilteringTimeTaken, documentFilteredStudents.length, overviewStudents.length)
+  logger.debug(
+    `Finished applying document filters. Time taken: {TimeTaken} ms. Resulting student count {FilteredCount} of {TotalCount} students`,
+    documentFilteringTimeTaken,
+    documentFilteredStudents.length,
+    overviewStudents.length
+  )
 
   const studentReturnLength = studentFilter?.top ?? documentFilteredStudents.length
 
@@ -159,6 +188,6 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
 
   return {
     students,
-    totalStudentCount: overviewStudents.length
+    totalStudentCount: documentFilteredStudents.length
   }
 }

--- a/src/lib/server/get-frontend-overview-students.ts
+++ b/src/lib/server/get-frontend-overview-students.ts
@@ -8,12 +8,12 @@ import { getDbClient } from "./db/get-db-client"
 import { HTTPError } from "./middleware/http-error"
 
 function buildStudentDocumentAccess(students: FrontendOverviewStudent[], principalEntraUserId: string): StudentDocumentAccess[] {
-  return students.map((s) => {
+  return students.map((student) => {
     const schoolAccessTypes = new Map<string, Set<string>>()
-    for (const a of s.principalAccessForStudent) {
-      const existing = schoolAccessTypes.get(a.schoolNumber) ?? new Set<string>()
-      existing.add(a.type)
-      schoolAccessTypes.set(a.schoolNumber, existing)
+    for (const access of student.principalAccessForStudent) {
+      const existing = schoolAccessTypes.get(access.schoolNumber) ?? new Set<string>()
+      existing.add(access.type)
+      schoolAccessTypes.set(access.schoolNumber, existing)
     }
 
     const subjectTeacherOnlySchoolNumbers = [...schoolAccessTypes.entries()]
@@ -21,10 +21,10 @@ function buildStudentDocumentAccess(students: FrontendOverviewStudent[], princip
       .map(([schoolNumber]) => schoolNumber)
 
     return {
-      studentId: s._id,
-      schoolNumbers: [...new Set(s.principalAccessForStudent.map((a) => a.schoolNumber))],
+      studentId: student._id,
+      schoolNumbers: [...new Set(student.principalAccessForStudent.map((access) => access.schoolNumber))],
       subjectTeacherOnlySchoolNumbers,
-      hasDataSharingConsent: s.dataSharingConsent,
+      hasDataSharingConsent: student.dataSharingConsent,
       principalEntraUserId
     }
   })
@@ -133,7 +133,7 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
     logger.info("Filtering students by templateIds: {TemplateIds}", studentFilter.templateIds)
     const studentAccess = buildStudentDocumentAccess(overviewStudents, principalAccess.entraUserId)
     const matchingIds = new Set(await dbClient.documents.getStudentIdsWithDocumentForTemplates(studentAccess, studentFilter.templateIds))
-    documentFilteredStudents = overviewStudents.filter((s) => matchingIds.has(s._id))
+    documentFilteredStudents = overviewStudents.filter((student) => matchingIds.has(student._id))
     logger.info("After templateIds filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
   }
 
@@ -141,7 +141,7 @@ export const getFrontendOverviewStudents = async (principalAccess: PrincipalAcce
     logger.info("Filtering students to those without any documents")
     const studentAccess = buildStudentDocumentAccess(documentFilteredStudents, principalAccess.entraUserId)
     const idsWithoutDocuments = new Set(await dbClient.documents.getStudentIdsWithoutDocuments(studentAccess))
-    documentFilteredStudents = documentFilteredStudents.filter((s) => idsWithoutDocuments.has(s._id))
+    documentFilteredStudents = documentFilteredStudents.filter((student) => idsWithoutDocuments.has(student._id))
     logger.info("After hasNoDocuments filter: {FilteredCount} of {TotalCount} students remain", documentFilteredStudents.length, overviewStudents.length)
   }
 

--- a/src/lib/shared-authorization/authorization.ts
+++ b/src/lib/shared-authorization/authorization.ts
@@ -10,6 +10,7 @@ import type {
   StudentDataSharingConsent,
   StudentDocument
 } from "$lib/types/db/shared-types"
+import { SUBJECT_TEACHER_ACCESS_TYPES } from "$lib/utils/access-constants"
 
 export const isSystemAdmin = (authenticatedPrincipal: AuthenticatedPrincipal, APP_INFO: ApplicationInfo): boolean => {
   return authenticatedPrincipal.roles.includes(APP_INFO.ROLES.ADMIN)
@@ -49,7 +50,7 @@ export const canManageManualStudentsOnSchool = (principalAccess: Access, schoolN
 }
 
 export const isOnlySubjectTeacher = (accessToStudent: PrincipalAccessForStudent[]): boolean => {
-  return accessToStudent.every((accessEntry) => accessEntry.type === "AUTOMATISK-UNDERVISNINGSGRUPPE-TILGANG" || accessEntry.type === "AUTOMATISK-KLASSE-TILGANG")
+  return accessToStudent.every((accessEntry) => (SUBJECT_TEACHER_ACCESS_TYPES as readonly string[]).includes(accessEntry.type))
 }
 
 export const canViewStudentDocument = (

--- a/src/lib/types/app-types.ts
+++ b/src/lib/types/app-types.ts
@@ -125,10 +125,16 @@ export type ApplicationInfo = {
   SCREEN_SAVER_INACTIVITY_TIMEOUT_SECONDS: number
 }
 
+export type DocumentTemplateFilterOption = {
+  _id: string
+  name: string
+}
+
 export type RootLayoutData = {
   APP_INFO: ApplicationInfo
   authenticatedPrincipal: AuthenticatedPrincipal
   principalAccess: PrincipalAccess | null
+  documentTemplateFilterOptions: DocumentTemplateFilterOption[]
   studentCheckBoxes: StudentCheckBox[]
   schools: SchoolInfo[]
 }

--- a/src/lib/types/app-types.ts
+++ b/src/lib/types/app-types.ts
@@ -182,6 +182,8 @@ export type TemplateInfo = {
 
 export type FrontendOverviewStudentFilter = Omit<CachedFrontendStudentFilter, "sortBy"> & {
   studentCheckBoxIds?: string[]
+  templateIds?: string[]
+  hasNoDocuments?: boolean
   sortBy?: "studentName" | "className" | "contactTeacherName" | "lastActivity"
   sortDirection?: "ascending" | "descending"
   top?: number

--- a/src/lib/types/db/db-client.ts
+++ b/src/lib/types/db/db-client.ts
@@ -75,11 +75,23 @@ export interface IStudentsDbClient {
   updateManualStudent(manualStudent: UpdateAppStudent): Promise<string>
 }
 
+export type StudentDocumentAccess = {
+  studentId: string
+  /** Direct school access derived from principalAccessForStudent */
+  schoolNumbers: string[]
+  /** Subset of schoolNumbers where the principal's only access type is subject teacher */
+  subjectTeacherOnlySchoolNumbers: string[]
+  /** When true, the principal has consent-based access to all of the student's schools */
+  hasDataSharingConsent: boolean
+  /** entraUserId of the principal — used to include documents the principal themselves created, even at subject-teacher-only schools */
+  principalEntraUserId: string
+}
+
 export interface IDocumentsDbClient {
   getStudentDocuments(studentId: string): Promise<StudentDocument[]>
   getStudentDocumentById(documentId: string): Promise<StudentDocument | null>
-  getStudentIdsWithoutDocuments(studentIds: string[]): Promise<string[]>
-  getStudentIdsWithDocumentForTemplates(studentIds: string[], templateIds: string[]): Promise<string[]>
+  getStudentIdsWithoutDocuments(studentAccess: StudentDocumentAccess[]): Promise<string[]>
+  getStudentIdsWithDocumentForTemplates(studentAccess: StudentDocumentAccess[], templateIds: string[]): Promise<string[]>
   createStudentDocument(document: NewStudentDocument): Promise<string>
   updateStudentDocument(documentId: string, documentUpdate: StudentDocumentUpdate): Promise<string>
   deleteStudentDocument(document: StudentDocument): Promise<void>

--- a/src/lib/types/db/db-client.ts
+++ b/src/lib/types/db/db-client.ts
@@ -78,6 +78,8 @@ export interface IStudentsDbClient {
 export interface IDocumentsDbClient {
   getStudentDocuments(studentId: string): Promise<StudentDocument[]>
   getStudentDocumentById(documentId: string): Promise<StudentDocument | null>
+  getStudentIdsWithoutDocuments(studentIds: string[]): Promise<string[]>
+  getStudentIdsWithDocumentForTemplates(studentIds: string[], templateIds: string[]): Promise<string[]>
   createStudentDocument(document: NewStudentDocument): Promise<string>
   updateStudentDocument(documentId: string, documentUpdate: StudentDocumentUpdate): Promise<string>
   deleteStudentDocument(document: StudentDocument): Promise<void>

--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -455,7 +455,7 @@ export type StudentDocumentUpdate = DocumentBase & DocumentInput
 
 export type DbEncryptedStudentDocumentUpdate = Omit<StudentDocumentUpdate, "title" | "content" | "template"> & {
   template: {
-    _id: string
+    _id: ObjectId
     name: Binary
     version: number
   }
@@ -468,9 +468,14 @@ export type StudentDocument = NewStudentDocument & {
   isDocumentLocked: boolean
 }
 
-export type NewDbStudentDocument = Omit<NewStudentDocument, "student"> & {
+export type NewDbStudentDocument = Omit<NewStudentDocument, "student" | "template"> & {
   student: {
     _id: ObjectId
+  }
+  template: {
+    _id: ObjectId
+    name: string
+    version: number
   }
 }
 
@@ -480,7 +485,7 @@ export type DbStudentDocument = NewDbStudentDocument & {
 
 export type NewDbEncryptedStudentDocument = Omit<NewDbStudentDocument, "title" | "content" | "messages" | "template"> & {
   template: {
-    _id: string
+    _id: ObjectId
     name: Binary
     version: number
   }
@@ -505,7 +510,7 @@ export type GroupDocumentUpdate = DocumentBase & DocumentInput
 
 export type DbEncryptedGroupDocumentUpdate = Omit<GroupDocumentUpdate, "title" | "content" | "template"> & {
   template: {
-    _id: string
+    _id: ObjectId
     name: Binary
     version: number
   }
@@ -518,9 +523,14 @@ export type GroupDocument = NewGroupDocument & {
   isDocumentLocked: boolean
 }
 
-export type NewDbGroupDocument = Omit<NewGroupDocument, "group"> & {
+export type NewDbGroupDocument = Omit<NewGroupDocument, "group" | "template"> & {
   group: {
     systemId: string
+  }
+  template: {
+    _id: ObjectId
+    name: string
+    version: number
   }
 }
 
@@ -530,7 +540,7 @@ export type DbGroupDocument = NewDbGroupDocument & {
 
 export type NewDbEncryptedGroupDocument = Omit<NewDbGroupDocument, "title" | "content" | "messages" | "template"> & {
   template: {
-    _id: string
+    _id: ObjectId
     name: Binary
     version: number
   }

--- a/src/lib/utils/access-constants.ts
+++ b/src/lib/utils/access-constants.ts
@@ -1,5 +1,7 @@
 import type { AccessEntry } from "$lib/types/app-types"
 
+export const SUBJECT_TEACHER_ACCESS_TYPES = ["AUTOMATISK-UNDERVISNINGSGRUPPE-TILGANG", "AUTOMATISK-KLASSE-TILGANG"] as const
+
 export const ACCESS_TYPE_DISPLAY_NAMES: Record<AccessEntry["type"], string> = {
   "AUTOMATISK-KLASSE-TILGANG": "Klasselærer (InSchool) for",
   "AUTOMATISK-KONTAKTLÆRERGRUPPE-TILGANG": "Kontaktlærer (InSchool) for",

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -3,7 +3,7 @@ import { APP_INFO } from "$lib/server/app-info"
 import { getPrincipalAccess } from "$lib/server/authorization/principal-access"
 import { getDbClient } from "$lib/server/db/get-db-client"
 import { serverLoadRequestMiddleware } from "$lib/server/middleware/http-request"
-import type { PrincipalAccess, RootLayoutData } from "$lib/types/app-types"
+import type { DocumentTemplateFilterOption, PrincipalAccess, RootLayoutData } from "$lib/types/app-types"
 import type { IDbClient } from "$lib/types/db/db-client"
 import type { SchoolInfo } from "$lib/types/db/shared-types"
 import type { ServerLoadNextFunction } from "$lib/types/middleware/http-request"
@@ -21,6 +21,7 @@ const layoutLoad: ServerLoadNextFunction<RootLayoutData> = async ({ principal })
       APP_INFO,
       principalAccess,
       studentCheckBoxes: [],
+      documentTemplateFilterOptions: [],
       schools: []
     }
   }
@@ -37,10 +38,15 @@ const layoutLoad: ServerLoadNextFunction<RootLayoutData> = async ({ principal })
   }))
   logger.info(`Found ${schoolsFromDb.length} schools`)
 
+  logger.info("Fetching student document templates")
+  const documentTemplateFilterOptions: DocumentTemplateFilterOption[] = (await dbClient.documentContentTemplates.getDocumentContentTemplates({ student: true })).map(({ _id, name }) => ({ _id, name }))
+  logger.info(`Found ${documentTemplateFilterOptions.length} document content templates`)
+
   return {
     authenticatedPrincipal: principal,
     APP_INFO,
     principalAccess,
+    documentTemplateFilterOptions,
     studentCheckBoxes: studentCheckBoxes.sort((a, b) => a.sort - b.sort),
     schools: schoolsInfo
   }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -39,7 +39,9 @@ const layoutLoad: ServerLoadNextFunction<RootLayoutData> = async ({ principal })
   logger.info(`Found ${schoolsFromDb.length} schools`)
 
   logger.info("Fetching student document templates")
-  const documentTemplateFilterOptions: DocumentTemplateFilterOption[] = (await dbClient.documentContentTemplates.getDocumentContentTemplates({ student: true })).map(({ _id, name }) => ({ _id, name }))
+  const documentTemplateFilterOptions: DocumentTemplateFilterOption[] = (await dbClient.documentContentTemplates.getDocumentContentTemplates({ student: true }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ _id, name }) => ({ _id, name }))
   logger.info(`Found ${documentTemplateFilterOptions.length} document content templates`)
 
   return {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
   import AppHeader from "$lib/components/AppHeader.svelte"
   import ScreenSaver from "$lib/components/ScreenSaver.svelte"
   import type { NoSlashString } from "$lib/types/api/api-route-map.js"
-  import type { FrontendOverviewStudent, FrontendOverviewStudentFilter } from "$lib/types/app-types.js"
+  import type { DocumentTemplateFilterOption, FrontendOverviewStudent, FrontendOverviewStudentFilter } from "$lib/types/app-types.js"
   import type { StudentCheckBox } from "$lib/types/db/shared-types.js"
   import { prettifyDateTime } from "$lib/utils/dates.js"
   import { STUDENT_CHECKBOX_DISPLAY_NAMES } from "$lib/utils/student-checkbox-constants"
@@ -29,8 +29,13 @@
   const followUpStudentCheckBoxes: StudentCheckBox[] = enabledStudentCheckBoxes.filter((checkbox: StudentCheckBox) => checkbox.type === "FOLLOW_UP")
   const facilitationStudentCheckBoxes: StudentCheckBox[] = enabledStudentCheckBoxes.filter((checkbox: StudentCheckBox) => checkbox.type === "FACILITATION")
 
+  // svelte-ignore state_referenced_locally
+  const studentDocumentTemplates: DocumentTemplateFilterOption[] = data.documentTemplateFilterOptions
+
   let selectedFollowUpStudentCheckBoxes: string[] = $state([])
   let selectedFacilitationStudentCheckBoxes: string[] = $state([])
+  let selectedTemplateIds: string[] = $state([])
+  let hasNoDocuments: boolean = $state(false)
 
   let studentOverviewFilter: FrontendOverviewStudentFilter = $state({
     className: "",
@@ -65,6 +70,18 @@
     }
 
     selectedFacilitationStudentCheckBoxes = selectedFacilitationStudentCheckBoxes.filter((id: string) => id !== studentCheckBoxId)
+  }
+
+  const getTemplate = (templateId: string): DocumentTemplateFilterOption => {
+    const template = studentDocumentTemplates.find((t: DocumentTemplateFilterOption) => t._id === templateId)
+    if (!template) {
+      throw new Error(`No template found for id ${templateId}`)
+    }
+    return template
+  }
+
+  const removeTemplateFilter = (templateId: string): void => {
+    selectedTemplateIds = selectedTemplateIds.filter((id: string) => id !== templateId)
   }
 
   type OverviewStudentsState = {
@@ -102,6 +119,12 @@
     selectedFollowUpStudentCheckBoxes.forEach((id) => {
       queryParams.append("studentCheckBoxIds", id)
     })
+    selectedTemplateIds.forEach((id) => {
+      queryParams.append("templateIds", id)
+    })
+    if (hasNoDocuments) {
+      queryParams.append("hasNoDocuments", "true")
+    }
 
     if (studentOverviewFilter.sortBy) {
       queryParams.append("sortBy", studentOverviewFilter.sortBy)
@@ -143,8 +166,10 @@
   // Instant load on checkbox-filters, sorting and on mount
   $effect(() => {
     const _studentCheckBoxIds = [...selectedFacilitationStudentCheckBoxes, ...selectedFollowUpStudentCheckBoxes]
+    const _documentFilters = [...selectedTemplateIds, hasNoDocuments]
     const _sorting = studentOverviewFilter.sortBy ? { sortBy: studentOverviewFilter.sortBy, sortDirection: studentOverviewFilter.sortDirection } : undefined
     void _studentCheckBoxIds // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
+    void _documentFilters // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
     void _sorting // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
 
     untrack(() => {
@@ -200,6 +225,12 @@
             {#each selectedFacilitationStudentCheckBoxes.map(getStudentCheckBox) as selectedFacilitationStudentCheckBox}
               <button class="ds-chip chip-facilitation" id={selectedFacilitationStudentCheckBox._id} aria-label={`Fjern ${selectedFacilitationStudentCheckBox.value}`} onclick={() => removeFacilitationStudentCheckBoxFilter(selectedFacilitationStudentCheckBox._id)} data-removable="true">{selectedFacilitationStudentCheckBox.value}</button>
             {/each}
+            {#each selectedTemplateIds.map(getTemplate) as template}
+              <button class="ds-chip chip-document-template" id={template._id} aria-label={`Fjern ${template.name}`} onclick={() => removeTemplateFilter(template._id)} data-removable="true">{template.name}</button>
+            {/each}
+            {#if hasNoDocuments}
+              <button class="ds-chip chip-no-documents" aria-label="Fjern filter: Uten dokumenter" onclick={() => { hasNoDocuments = false }} data-removable="true">Uten dokumenter</button>
+            {/if}
           </div>
 
           <div class="student-filters-content">
@@ -251,6 +282,51 @@
                   </ul>
                   <hr class="ds-divider" />
                   <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedFacilitationStudentCheckBoxes = []} disabled={selectedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
+                </div>
+              {/if}
+            </div>
+
+            <button
+              class="ds-button"
+              data-variant="secondary"
+              type="button"
+              popovertarget="document-filters-action-container"
+              aria-label="Dokumentfilter"
+              data-tooltip="Dokumentfilter"
+              data-placement="top"
+              data-autoplacement="true"
+            >
+              <span class="material-symbols-outlined">description</span>
+            </button>
+            <div id="document-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
+              <div class="document-filters-status">
+                <h2 class="ds-heading">Dokumentstatus</h2>
+                <hr class="ds-divider" />
+                <ul class="ds-list">
+                  <li>
+                    <ds-field class="ds-field">
+                      <input id="document-filters-no-documents" bind:checked={hasNoDocuments} onchange={() => { selectedTemplateIds = [] }} class="ds-input" type="checkbox" />
+                      <label for="document-filters-no-documents" class="ds-label" data-weight="regular">Uten dokumenter</label>
+                    </ds-field>
+                  </li>
+                </ul>
+              </div>
+              {#if studentDocumentTemplates.length > 0}
+                <div class="document-filters-templates">
+                  <h2 class="ds-heading">Maler</h2>
+                  <hr class="ds-divider" />
+                  <ul class="ds-list">
+                    {#each studentDocumentTemplates as template}
+                      <li>
+                        <ds-field class="ds-field">
+                          <input id="document-filters-{template._id}" bind:group={selectedTemplateIds} onchange={() => { hasNoDocuments = false }} class="ds-input" type="checkbox" value={template._id} />
+                          <label for="document-filters-{template._id}" class="ds-label" data-weight="regular">{template.name}</label>
+                        </ds-field>
+                      </li>
+                    {/each}
+                  </ul>
+                  <hr class="ds-divider" />
+                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedTemplateIds = []} disabled={selectedTemplateIds.length === 0}>Fjern alle filter</button>
                 </div>
               {/if}
             </div>
@@ -443,6 +519,30 @@
 
     .chip-facilitation {
         background-color: var(--ds-color-brand1-text-subtle);
+    }
+
+    .chip-document-template {
+        background-color: var(--ds-color-brand2-text-subtle);
+    }
+
+    .chip-no-documents {
+        background-color: var(--ds-color-neutral-text-subtle);
+    }
+
+    #document-filters-action-container {
+        --dsc-popover-max-width: 100%;
+    }
+
+    #document-filters-action-container:popover-open {
+        display: flex;
+    }
+
+    .document-filters-status > ul > li, .document-filters-templates > ul > li {
+        list-style: none;
+    }
+
+    .document-filters-status > ul, .document-filters-templates > ul {
+        padding-left: var(--ds-size-2);
     }
 
     .students-side-menu {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -349,7 +349,7 @@
             <span class="ds-tag" data-variant="outline" data-color="brand3">{template.name}</span>
           {/each}
           {#if appliedHasNoDocuments}
-            <span class="ds-tag" data-variant="outline" data-color="neutral">Uten dokumenter</span>
+            <span class="ds-tag" data-variant="outline" data-color="neutral">Har ingen notater</span>
           {/if}
         </div>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,6 +37,30 @@
   let selectedTemplateIds: string[] = $state([])
   let hasNoDocuments: boolean = $state(false)
 
+  let appliedFollowUpStudentCheckBoxes: string[] = $state([])
+  let appliedFacilitationStudentCheckBoxes: string[] = $state([])
+  let appliedTemplateIds: string[] = $state([])
+  let appliedHasNoDocuments: boolean = $state(false)
+
+  function hasTheSameItems(arr1: string[], arr2: string[]): boolean {
+    if (arr1.length !== arr2.length) {
+      return false;
+    }
+    const set2 = new Set(arr2);
+    return arr1.every(item => set2.has(item));
+  }
+
+  const hasCheckboxFilterChanges: boolean = $derived.by(() => {
+    return !hasTheSameItems(selectedFollowUpStudentCheckBoxes, appliedFollowUpStudentCheckBoxes) ||
+           !hasTheSameItems(selectedFacilitationStudentCheckBoxes, appliedFacilitationStudentCheckBoxes)
+  })
+
+  const hasDocumentFilterChanges: boolean = $derived.by(() => {
+    if (!hasTheSameItems(selectedTemplateIds, appliedTemplateIds)) { return true }
+    if (hasNoDocuments !== appliedHasNoDocuments) { return true }
+    return false
+  })
+
   let studentOverviewFilter: FrontendOverviewStudentFilter = $state({
     className: "",
     contactTeacherName: "",
@@ -56,22 +80,6 @@
     return studentCheckBox
   }
 
-  const removeFollowUpStudentCheckBoxFilter = (studentCheckBoxId: string): void => {
-    if (!selectedFollowUpStudentCheckBoxes.includes(studentCheckBoxId)) {
-      throw new Error("Trying to remove document filter that is not selected, something wrong here gitt")
-    }
-
-    selectedFollowUpStudentCheckBoxes = selectedFollowUpStudentCheckBoxes.filter((id: string) => id !== studentCheckBoxId)
-  }
-
-  const removeFacilitationStudentCheckBoxFilter = (studentCheckBoxId: string): void => {
-    if (!selectedFacilitationStudentCheckBoxes.includes(studentCheckBoxId)) {
-      throw new Error("Trying to remove document filter that is not selected, something wrong here gitt")
-    }
-
-    selectedFacilitationStudentCheckBoxes = selectedFacilitationStudentCheckBoxes.filter((id: string) => id !== studentCheckBoxId)
-  }
-
   const getTemplate = (templateId: string): DocumentTemplateFilterOption => {
     const template = studentDocumentTemplates.find((t: DocumentTemplateFilterOption) => t._id === templateId)
     if (!template) {
@@ -80,8 +88,12 @@
     return template
   }
 
-  const removeTemplateFilter = (templateId: string): void => {
-    selectedTemplateIds = selectedTemplateIds.filter((id: string) => id !== templateId)
+  function applyFilters(): void {
+    appliedFollowUpStudentCheckBoxes = [...selectedFollowUpStudentCheckBoxes]
+    appliedFacilitationStudentCheckBoxes = [...selectedFacilitationStudentCheckBoxes]
+    appliedTemplateIds = [...selectedTemplateIds]
+    appliedHasNoDocuments = hasNoDocuments
+    updateOverviewStudents()
   }
 
   type OverviewStudentsState = {
@@ -98,7 +110,7 @@
     totalStudentCount: 0
   })
 
-  const updateOverviewStudents = async (): Promise<void> => {
+  async function updateOverviewStudents(): Promise<void> {
     overviewStudents.isLoading = true
     overviewStudents.errorMessage = null
 
@@ -163,14 +175,10 @@
     }, 300)
   }
 
-  // Instant load on checkbox-filters, sorting and on mount
+  // Instant load on sort change and on mount
   $effect(() => {
-    const _studentCheckBoxIds = [...selectedFacilitationStudentCheckBoxes, ...selectedFollowUpStudentCheckBoxes]
-    const _documentFilters = [...selectedTemplateIds, hasNoDocuments]
     const _sorting = studentOverviewFilter.sortBy ? { sortBy: studentOverviewFilter.sortBy, sortDirection: studentOverviewFilter.sortDirection } : undefined
-    void _studentCheckBoxIds // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
-    void _documentFilters // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
-    void _sorting // read to register reactive dependency before untrack() - this line is here only to silence the warning about unused constant
+    void _sorting // read to register reactive dependency before untrack()
 
     untrack(() => {
       updateOverviewStudents()
@@ -219,17 +227,17 @@
 
         <div class="student-filters-container">
           <div class="student-filters-selected">
-            {#each selectedFollowUpStudentCheckBoxes.map(getStudentCheckBox) as selectedFollowUpStudentCheckBox}
-              <button class="ds-chip chip-followup" id={selectedFollowUpStudentCheckBox._id} aria-label={`Fjern ${selectedFollowUpStudentCheckBox.value}`} onclick={() => removeFollowUpStudentCheckBoxFilter(selectedFollowUpStudentCheckBox._id)} data-removable="true">{selectedFollowUpStudentCheckBox.value}</button>
+            {#each appliedFollowUpStudentCheckBoxes.map(getStudentCheckBox) as selectedFollowUpStudentCheckBox}
+              <span class="ds-tag" data-variant="outline" data-color="brand1">{selectedFollowUpStudentCheckBox.value}</span>
             {/each}
-            {#each selectedFacilitationStudentCheckBoxes.map(getStudentCheckBox) as selectedFacilitationStudentCheckBox}
-              <button class="ds-chip chip-facilitation" id={selectedFacilitationStudentCheckBox._id} aria-label={`Fjern ${selectedFacilitationStudentCheckBox.value}`} onclick={() => removeFacilitationStudentCheckBoxFilter(selectedFacilitationStudentCheckBox._id)} data-removable="true">{selectedFacilitationStudentCheckBox.value}</button>
+            {#each appliedFacilitationStudentCheckBoxes.map(getStudentCheckBox) as selectedFacilitationStudentCheckBox}
+              <span class="ds-tag" data-variant="outline" data-color="brand2">{selectedFacilitationStudentCheckBox.value}</span>
             {/each}
-            {#each selectedTemplateIds.map(getTemplate) as template}
-              <button class="ds-chip chip-document-template" id={template._id} aria-label={`Fjern ${template.name}`} onclick={() => removeTemplateFilter(template._id)} data-removable="true">{template.name}</button>
+            {#each appliedTemplateIds.map(getTemplate) as template}
+              <span class="ds-tag" data-variant="outline" data-color="brand3">{template.name}</span>
             {/each}
-            {#if hasNoDocuments}
-              <button class="ds-chip chip-no-documents" aria-label="Fjern filter: Uten dokumenter" onclick={() => { hasNoDocuments = false }} data-removable="true">Uten dokumenter</button>
+            {#if appliedHasNoDocuments}
+              <span class="ds-tag" data-variant="outline" data-color="neutral">Uten dokumenter</span>
             {/if}
           </div>
 
@@ -248,42 +256,48 @@
               <span class="material-symbols-outlined">filter_list</span>
             </button>
             <div id="student-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
-              {#if followUpStudentCheckBoxes.length > 0}
-                <div class="student-filters-followup">
-                  <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FOLLOW_UP.single}</h2>
-                  <hr class="ds-divider" />
-                  <ul class="ds-list">
-                    {#each followUpStudentCheckBoxes as followUpStudentCheckBox}
-                      <li>
-                        <ds-field class="ds-field">
-                          <input id="student-filters-{followUpStudentCheckBox._id}" bind:group={selectedFollowUpStudentCheckBoxes} class="ds-input" type="checkbox" value={followUpStudentCheckBox._id} />
-                          <label for="student-filters-{followUpStudentCheckBox._id}" class="ds-label" data-weight="regular">{followUpStudentCheckBox.value}</label>
-                        </ds-field>
-                      </li>
-                    {/each}
-                  </ul>
-                  <hr class="ds-divider" />
-                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedFollowUpStudentCheckBoxes = []} disabled={selectedFollowUpStudentCheckBoxes.length === 0}>Fjern alle filter</button>
-                </div>
-              {/if}
-              {#if facilitationStudentCheckBoxes.length > 0}
-                <div class="student-filters-facilitation">
-                  <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FACILITATION.plural}</h2>
-                  <hr class="ds-divider" />
-                  <ul class="ds-list">
-                    {#each facilitationStudentCheckBoxes as facilitationStudentCheckBox}
-                      <li>
-                        <ds-field class="ds-field">
-                          <input id="student-filters-{facilitationStudentCheckBox._id}" bind:group={selectedFacilitationStudentCheckBoxes} class="ds-input" type="checkbox" value={facilitationStudentCheckBox._id} />
-                          <label for="student-filters-{facilitationStudentCheckBox._id}" class="ds-label" data-weight="regular">{facilitationStudentCheckBox.value}</label>
-                        </ds-field>
-                      </li>
-                    {/each}
-                  </ul>
-                  <hr class="ds-divider" />
-                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedFacilitationStudentCheckBoxes = []} disabled={selectedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
-                </div>
-              {/if}
+              <div class="student-filters">
+                {#if followUpStudentCheckBoxes.length > 0}
+                  <div class="student-filters-followup">
+                    <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FOLLOW_UP.single}</h2>
+                    <hr class="ds-divider" />
+                    <ul class="ds-list">
+                      {#each followUpStudentCheckBoxes as followUpStudentCheckBox}
+                        <li>
+                          <ds-field class="ds-field">
+                            <input id="student-filters-{followUpStudentCheckBox._id}" bind:group={selectedFollowUpStudentCheckBoxes} class="ds-input" type="checkbox" value={followUpStudentCheckBox._id} />
+                            <label for="student-filters-{followUpStudentCheckBox._id}" class="ds-label" data-weight="regular">{followUpStudentCheckBox.value}</label>
+                          </ds-field>
+                        </li>
+                      {/each}
+                    </ul>
+                  </div>
+                {/if}
+                {#if facilitationStudentCheckBoxes.length > 0}
+                  <div class="student-filters-facilitation">
+                    <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FACILITATION.plural}</h2>
+                    <hr class="ds-divider" />
+                    <ul class="ds-list">
+                      {#each facilitationStudentCheckBoxes as facilitationStudentCheckBox}
+                        <li>
+                          <ds-field class="ds-field">
+                            <input id="student-filters-{facilitationStudentCheckBox._id}" bind:group={selectedFacilitationStudentCheckBoxes} class="ds-input" type="checkbox" value={facilitationStudentCheckBox._id} />
+                            <label for="student-filters-{facilitationStudentCheckBox._id}" class="ds-label" data-weight="regular">{facilitationStudentCheckBox.value}</label>
+                          </ds-field>
+                        </li>
+                      {/each}
+                    </ul>
+                  </div>
+                {/if}
+              </div>
+              <hr class="ds-divider" />
+              <div class="filters-footer">
+                <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedFollowUpStudentCheckBoxes = []; selectedFacilitationStudentCheckBoxes = []; }} disabled={selectedFollowUpStudentCheckBoxes.length === 0 && selectedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
+                <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasCheckboxFilterChanges}>
+                  <span class="material-symbols-outlined">check</span>
+                  Bruk filter
+                </button>            
+              </div>
             </div>
 
             <button
@@ -298,37 +312,37 @@
             >
               <span class="material-symbols-outlined">description</span>
             </button>
+
             <div id="document-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
-              <div class="document-filters-status">
-                <h2 class="ds-heading">Dokumentstatus</h2>
+              <div class="document-filters-templates">
+                <h2 class="ds-heading">Notat-typer</h2>
                 <hr class="ds-divider" />
                 <ul class="ds-list">
                   <li>
                     <ds-field class="ds-field">
-                      <input id="document-filters-no-documents" bind:checked={hasNoDocuments} onchange={() => { selectedTemplateIds = [] }} class="ds-input" type="checkbox" />
-                      <label for="document-filters-no-documents" class="ds-label" data-weight="regular">Uten dokumenter</label>
+                      <input id="document-filters-no-documents" bind:checked={hasNoDocuments} onclick={() => { selectedTemplateIds = [] }} class="ds-input" type="checkbox" />
+                      <label for="document-filters-no-documents" class="ds-label" data-weight="regular">Har ingen notater</label>
                     </ds-field>
                   </li>
+                  <hr class="ds-divider" />
+                  {#each studentDocumentTemplates as template}
+                    <li>
+                      <ds-field class="ds-field">
+                        <input id="document-filters-{template._id}" bind:group={selectedTemplateIds} onclick={() => { hasNoDocuments = false }} class="ds-input" type="checkbox" value={template._id} />
+                        <label for="document-filters-{template._id}" class="ds-label" data-weight="regular">{template.name}</label>
+                      </ds-field>
+                    </li>
+                  {/each}
                 </ul>
-              </div>
-              {#if studentDocumentTemplates.length > 0}
-                <div class="document-filters-templates">
-                  <h2 class="ds-heading">Maler</h2>
-                  <hr class="ds-divider" />
-                  <ul class="ds-list">
-                    {#each studentDocumentTemplates as template}
-                      <li>
-                        <ds-field class="ds-field">
-                          <input id="document-filters-{template._id}" bind:group={selectedTemplateIds} onchange={() => { hasNoDocuments = false }} class="ds-input" type="checkbox" value={template._id} />
-                          <label for="document-filters-{template._id}" class="ds-label" data-weight="regular">{template.name}</label>
-                        </ds-field>
-                      </li>
-                    {/each}
-                  </ul>
-                  <hr class="ds-divider" />
+                <hr class="ds-divider" />
+                <div class="filters-footer">
                   <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedTemplateIds = []} disabled={selectedTemplateIds.length === 0}>Fjern alle filter</button>
+                  <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasDocumentFilterChanges} popovertarget="document-filters-action-container" popovertargetaction="hide">
+                    <span class="material-symbols-outlined">check</span>
+                    Bruk filter
+                  </button>
                 </div>
-              {/if}
+              </div>
             </div>
           </div>
         </div>
@@ -485,6 +499,11 @@
         align-items: center;
     }
 
+    .student-filters-content {
+        display: flex;
+        gap: var(--ds-size-2);
+    }
+
     #student-filters-action-container {
         --dsc-popover-max-width: 100%;
     }
@@ -503,30 +522,21 @@
         padding-left: var(--ds-size-2);
     }
 
-    #student-filters-action-container:popover-open {
+    .student-filters {
         display: flex;
+        gap: var(--ds-size-4);
+    }
+
+    .filters-footer {
+      display: flex;
+      justify-content: space-between;
+      gap: var(--ds-size-2);
     }
 
     .student-filters-selected {
         display: flex;
         gap: var(--ds-size-1) var(--ds-size-2);
         flex-wrap: wrap;
-    }
-
-    .chip-followup {
-        background-color: var(--dsc-chip-background--checked)
-    }
-
-    .chip-facilitation {
-        background-color: var(--ds-color-brand1-text-subtle);
-    }
-
-    .chip-document-template {
-        background-color: var(--ds-color-brand2-text-subtle);
-    }
-
-    .chip-no-documents {
-        background-color: var(--ds-color-neutral-text-subtle);
     }
 
     #document-filters-action-container {
@@ -537,11 +547,11 @@
         display: flex;
     }
 
-    .document-filters-status > ul > li, .document-filters-templates > ul > li {
+    .document-filters-templates > ul > li {
         list-style: none;
     }
 
-    .document-filters-status > ul, .document-filters-templates > ul {
+    .document-filters-templates > ul {
         padding-left: var(--ds-size-2);
     }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,20 +44,23 @@
 
   function hasTheSameItems(arr1: string[], arr2: string[]): boolean {
     if (arr1.length !== arr2.length) {
-      return false;
+      return false
     }
-    const set2 = new Set(arr2);
-    return arr1.every(item => set2.has(item));
+    const set2 = new Set(arr2)
+    return arr1.every((item) => set2.has(item))
   }
 
   const hasCheckboxFilterChanges: boolean = $derived.by(() => {
-    return !hasTheSameItems(selectedFollowUpStudentCheckBoxes, appliedFollowUpStudentCheckBoxes) ||
-           !hasTheSameItems(selectedFacilitationStudentCheckBoxes, appliedFacilitationStudentCheckBoxes)
+    return !hasTheSameItems(selectedFollowUpStudentCheckBoxes, appliedFollowUpStudentCheckBoxes) || !hasTheSameItems(selectedFacilitationStudentCheckBoxes, appliedFacilitationStudentCheckBoxes)
   })
 
   const hasDocumentFilterChanges: boolean = $derived.by(() => {
-    if (!hasTheSameItems(selectedTemplateIds, appliedTemplateIds)) { return true }
-    if (hasNoDocuments !== appliedHasNoDocuments) { return true }
+    if (!hasTheSameItems(selectedTemplateIds, appliedTemplateIds)) {
+      return true
+    }
+    if (hasNoDocuments !== appliedHasNoDocuments) {
+      return true
+    }
     return false
   })
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -128,16 +128,16 @@
       queryParams.append("contactTeacherName", studentOverviewFilter.contactTeacherName)
     }
 
-    selectedFacilitationStudentCheckBoxes.forEach((id) => {
+    appliedFacilitationStudentCheckBoxes.forEach((id) => {
       queryParams.append("studentCheckBoxIds", id)
     })
-    selectedFollowUpStudentCheckBoxes.forEach((id) => {
+    appliedFollowUpStudentCheckBoxes.forEach((id) => {
       queryParams.append("studentCheckBoxIds", id)
     })
-    selectedTemplateIds.forEach((id) => {
+    appliedTemplateIds.forEach((id) => {
       queryParams.append("templateIds", id)
     })
-    if (hasNoDocuments) {
+    if (appliedHasNoDocuments) {
       queryParams.append("hasNoDocuments", "true")
     }
 
@@ -295,7 +295,7 @@
               </div>
               <hr class="ds-divider" />
               <div class="filters-footer">
-                <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedFollowUpStudentCheckBoxes = []; selectedFacilitationStudentCheckBoxes = []; }} disabled={selectedFollowUpStudentCheckBoxes.length === 0 && selectedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
+                <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedFollowUpStudentCheckBoxes = []; selectedFacilitationStudentCheckBoxes = []; applyFilters() }} disabled={appliedFollowUpStudentCheckBoxes.length === 0 && appliedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
                 <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasCheckboxFilterChanges}>
                   <span class="material-symbols-outlined">check</span>
                   Bruk filter
@@ -339,7 +339,7 @@
                 </ul>
                 <hr class="ds-divider" />
                 <div class="filters-footer">
-                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => selectedTemplateIds = []} disabled={selectedTemplateIds.length === 0}>Fjern alle filter</button>
+                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedTemplateIds = []; hasNoDocuments = false; applyFilters() }} disabled={appliedTemplateIds.length === 0 && !appliedHasNoDocuments}>Fjern alle filter</button>
                   <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasDocumentFilterChanges} popovertarget="document-filters-action-container" popovertargetaction="hide">
                     <span class="material-symbols-outlined">check</span>
                     Bruk filter

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -172,6 +172,7 @@
 
   const debouncedUpdateOverviewStudents = (): void => {
     clearTimeout(debounceTimer)
+    overviewStudents.isLoading = true
 
     debounceTimer = setTimeout(() => {
       updateOverviewStudents()
@@ -213,141 +214,143 @@
     {#if showStudentOverview}
       <div class="page-content">
         <h1 class="ds-heading" data-size="lg">Elever</h1>
-        <div class="student-search-container">
-          <ds-field class="ds-field">
-            <label for="student-name-search" class="ds-label" data-weight="medium">Navn</label>
-            <input id="student-name-search" class="ds-input" type="text" placeholder="Søk etter elev" bind:value={studentOverviewFilter.studentName} oninput={debouncedUpdateOverviewStudents} autocomplete="off" >
-          </ds-field>
-          <ds-field class="ds-field">
-            <label for="student-class-search" class="ds-label" data-weight="medium">Klasse</label>
-            <input id="student-class-search" class="ds-input" placeholder="Søk etter klasse" type="text" bind:value={studentOverviewFilter.className} oninput={debouncedUpdateOverviewStudents} autocomplete="off" />
-          </ds-field>
-          <ds-field class="ds-field">
-            <label for="student-teacher-search" class="ds-label" data-weight="medium">Kontaktlærer</label>
-            <input id="student-teacher-search" class="ds-input" placeholder="Søk etter kontaktlærer" type="text" bind:value={studentOverviewFilter.contactTeacherName} oninput={debouncedUpdateOverviewStudents} autocomplete="off" />
-          </ds-field>
-        </div>
-
-        <div class="student-filters-container">
-          <div class="student-filters-selected">
-            {#each appliedFollowUpStudentCheckBoxes.map(getStudentCheckBox) as selectedFollowUpStudentCheckBox}
-              <span class="ds-tag" data-variant="outline" data-color="brand1">{selectedFollowUpStudentCheckBox.value}</span>
-            {/each}
-            {#each appliedFacilitationStudentCheckBoxes.map(getStudentCheckBox) as selectedFacilitationStudentCheckBox}
-              <span class="ds-tag" data-variant="outline" data-color="brand2">{selectedFacilitationStudentCheckBox.value}</span>
-            {/each}
-            {#each appliedTemplateIds.map(getTemplate) as template}
-              <span class="ds-tag" data-variant="outline" data-color="brand3">{template.name}</span>
-            {/each}
-            {#if appliedHasNoDocuments}
-              <span class="ds-tag" data-variant="outline" data-color="neutral">Uten dokumenter</span>
-            {/if}
+        <div class="student-search-and-filter-container">
+          <div class="student-search-container">
+            <ds-field class="ds-field">
+              <label for="student-name-search" class="ds-label" data-weight="medium">Navn</label>
+              <input id="student-name-search" class="ds-input" type="text" placeholder="Søk etter elev" bind:value={studentOverviewFilter.studentName} oninput={debouncedUpdateOverviewStudents} autocomplete="off" >
+            </ds-field>
+            <ds-field class="ds-field">
+              <label for="student-class-search" class="ds-label" data-weight="medium">Klasse</label>
+              <input id="student-class-search" class="ds-input" placeholder="Søk etter klasse" type="text" bind:value={studentOverviewFilter.className} oninput={debouncedUpdateOverviewStudents} autocomplete="off" />
+            </ds-field>
+            <ds-field class="ds-field">
+              <label for="student-teacher-search" class="ds-label" data-weight="medium">Kontaktlærer</label>
+              <input id="student-teacher-search" class="ds-input" placeholder="Søk etter kontaktlærer" type="text" bind:value={studentOverviewFilter.contactTeacherName} oninput={debouncedUpdateOverviewStudents} autocomplete="off" />
+            </ds-field>
           </div>
 
-          <div class="student-filters-content">
-            <button
-              disabled={facilitationStudentCheckBoxes.length === 0 && followUpStudentCheckBoxes.length === 0}
-              class="ds-button"
-              data-variant="secondary"
-              type="button"
-              popovertarget="student-filters-action-container"
-              aria-label="Elevfilter"
-              data-tooltip="Elevfilter"
-              data-placement="top"
-              data-autoplacement="true"
-            >
-              <span class="material-symbols-outlined">filter_list</span>
-            </button>
-            <div id="student-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
-              <div class="student-filters">
-                {#if followUpStudentCheckBoxes.length > 0}
-                  <div class="student-filters-followup">
-                    <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FOLLOW_UP.single}</h2>
-                    <hr class="ds-divider" />
-                    <ul class="ds-list">
-                      {#each followUpStudentCheckBoxes as followUpStudentCheckBox}
-                        <li>
-                          <ds-field class="ds-field">
-                            <input id="student-filters-{followUpStudentCheckBox._id}" bind:group={selectedFollowUpStudentCheckBoxes} class="ds-input" type="checkbox" value={followUpStudentCheckBox._id} />
-                            <label for="student-filters-{followUpStudentCheckBox._id}" class="ds-label" data-weight="regular">{followUpStudentCheckBox.value}</label>
-                          </ds-field>
-                        </li>
-                      {/each}
-                    </ul>
-                  </div>
-                {/if}
-                {#if facilitationStudentCheckBoxes.length > 0}
-                  <div class="student-filters-facilitation">
-                    <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FACILITATION.plural}</h2>
-                    <hr class="ds-divider" />
-                    <ul class="ds-list">
-                      {#each facilitationStudentCheckBoxes as facilitationStudentCheckBox}
-                        <li>
-                          <ds-field class="ds-field">
-                            <input id="student-filters-{facilitationStudentCheckBox._id}" bind:group={selectedFacilitationStudentCheckBoxes} class="ds-input" type="checkbox" value={facilitationStudentCheckBox._id} />
-                            <label for="student-filters-{facilitationStudentCheckBox._id}" class="ds-label" data-weight="regular">{facilitationStudentCheckBox.value}</label>
-                          </ds-field>
-                        </li>
-                      {/each}
-                    </ul>
-                  </div>
-                {/if}
-              </div>
-              <hr class="ds-divider" />
-              <div class="filters-footer">
-                <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedFollowUpStudentCheckBoxes = []; selectedFacilitationStudentCheckBoxes = []; applyFilters() }} disabled={appliedFollowUpStudentCheckBoxes.length === 0 && appliedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
-                <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasCheckboxFilterChanges}>
-                  <span class="material-symbols-outlined">check</span>
-                  Bruk filter
-                </button>            
-              </div>
-            </div>
-
-            <button
-              class="ds-button"
-              data-variant="secondary"
-              type="button"
-              popovertarget="document-filters-action-container"
-              aria-label="Dokumentfilter"
-              data-tooltip="Dokumentfilter"
-              data-placement="top"
-              data-autoplacement="true"
-            >
-              <span class="material-symbols-outlined">description</span>
-            </button>
-
-            <div id="document-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
-              <div class="document-filters-templates">
-                <h2 class="ds-heading">Notat-typer</h2>
-                <hr class="ds-divider" />
-                <ul class="ds-list">
-                  <li>
-                    <ds-field class="ds-field">
-                      <input id="document-filters-no-documents" bind:checked={hasNoDocuments} onclick={() => { selectedTemplateIds = [] }} class="ds-input" type="checkbox" />
-                      <label for="document-filters-no-documents" class="ds-label" data-weight="regular">Har ingen notater</label>
-                    </ds-field>
-                  </li>
-                  <hr class="ds-divider" />
-                  {#each studentDocumentTemplates as template}
-                    <li>
-                      <ds-field class="ds-field">
-                        <input id="document-filters-{template._id}" bind:group={selectedTemplateIds} onclick={() => { hasNoDocuments = false }} class="ds-input" type="checkbox" value={template._id} />
-                        <label for="document-filters-{template._id}" class="ds-label" data-weight="regular">{template.name}</label>
-                      </ds-field>
-                    </li>
-                  {/each}
-                </ul>
+          <div class="student-filters-container">
+            <div class="student-filters-content">
+              <button
+                disabled={facilitationStudentCheckBoxes.length === 0 && followUpStudentCheckBoxes.length === 0}
+                class="ds-button"
+                data-variant="secondary"
+                type="button"
+                popovertarget="student-filters-action-container"
+                aria-label="Elevfilter"
+                data-tooltip="Elevfilter"
+                data-placement="top"
+                data-autoplacement="true"
+              >
+                <span class="material-symbols-outlined">filter_list</span>
+              </button>
+              <div id="student-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
+                <div class="student-filters">
+                  {#if followUpStudentCheckBoxes.length > 0}
+                    <div class="student-filters-followup">
+                      <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FOLLOW_UP.single}</h2>
+                      <hr class="ds-divider" />
+                      <ul class="ds-list">
+                        {#each followUpStudentCheckBoxes as followUpStudentCheckBox}
+                          <li>
+                            <ds-field class="ds-field">
+                              <input id="student-filters-{followUpStudentCheckBox._id}" bind:group={selectedFollowUpStudentCheckBoxes} class="ds-input" type="checkbox" value={followUpStudentCheckBox._id} />
+                              <label for="student-filters-{followUpStudentCheckBox._id}" class="ds-label" data-weight="regular">{followUpStudentCheckBox.value}</label>
+                            </ds-field>
+                          </li>
+                        {/each}
+                      </ul>
+                    </div>
+                  {/if}
+                  {#if facilitationStudentCheckBoxes.length > 0}
+                    <div class="student-filters-facilitation">
+                      <h2 class="ds-heading">{STUDENT_CHECKBOX_DISPLAY_NAMES.FACILITATION.plural}</h2>
+                      <hr class="ds-divider" />
+                      <ul class="ds-list">
+                        {#each facilitationStudentCheckBoxes as facilitationStudentCheckBox}
+                          <li>
+                            <ds-field class="ds-field">
+                              <input id="student-filters-{facilitationStudentCheckBox._id}" bind:group={selectedFacilitationStudentCheckBoxes} class="ds-input" type="checkbox" value={facilitationStudentCheckBox._id} />
+                              <label for="student-filters-{facilitationStudentCheckBox._id}" class="ds-label" data-weight="regular">{facilitationStudentCheckBox.value}</label>
+                            </ds-field>
+                          </li>
+                        {/each}
+                      </ul>
+                    </div>
+                  {/if}
+                </div>
                 <hr class="ds-divider" />
                 <div class="filters-footer">
-                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedTemplateIds = []; hasNoDocuments = false; applyFilters() }} disabled={appliedTemplateIds.length === 0 && !appliedHasNoDocuments}>Fjern alle filter</button>
-                  <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasDocumentFilterChanges} popovertarget="document-filters-action-container" popovertargetaction="hide">
+                  <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedFollowUpStudentCheckBoxes = []; selectedFacilitationStudentCheckBoxes = [] }} disabled={selectedFollowUpStudentCheckBoxes.length === 0 && selectedFacilitationStudentCheckBoxes.length === 0}>Fjern alle filter</button>
+                  <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasCheckboxFilterChanges}>
                     <span class="material-symbols-outlined">check</span>
                     Bruk filter
-                  </button>
+                  </button>            
+                </div>
+              </div>
+
+              <button
+                class="ds-button"
+                data-variant="secondary"
+                type="button"
+                popovertarget="document-filters-action-container"
+                aria-label="Notatfilter"
+                data-tooltip="Notatfilter"
+                data-placement="top"
+                data-autoplacement="true"
+              >
+                <span class="material-symbols-outlined">description</span>
+              </button>
+
+              <div id="document-filters-action-container" class="ds-popover ds-dropdown" popover="auto" data-placement="bottom-end" data-variant="default">
+                <div class="document-filters-templates">
+                  <h2 class="ds-heading">Notat-typer</h2>
+                  <hr class="ds-divider" />
+                  <ul class="ds-list">
+                    <li>
+                      <ds-field class="ds-field">
+                        <input id="document-filters-no-documents" bind:checked={hasNoDocuments} onclick={() => { selectedTemplateIds = [] }} class="ds-input" type="checkbox" />
+                        <label for="document-filters-no-documents" class="ds-label" data-weight="regular">Har ingen notater</label>
+                      </ds-field>
+                    </li>
+                    <hr class="ds-divider" />
+                    {#each studentDocumentTemplates as template}
+                      <li>
+                        <ds-field class="ds-field">
+                          <input id="document-filters-{template._id}" bind:group={selectedTemplateIds} onclick={() => { hasNoDocuments = false }} class="ds-input" type="checkbox" value={template._id} />
+                          <label for="document-filters-{template._id}" class="ds-label" data-weight="regular">{template.name}</label>
+                        </ds-field>
+                      </li>
+                    {/each}
+                  </ul>
+                  <hr class="ds-divider" />
+                  <div class="filters-footer">
+                    <button class="ds-button" data-variant="tertiary" data-size="sm" type="button" onclick={() => { selectedTemplateIds = []; hasNoDocuments = false; }} disabled={selectedTemplateIds.length === 0 && !hasNoDocuments}>Fjern alle filter</button>
+                    <button class="ds-button" data-variant="primary" data-size="sm" type="button" onclick={applyFilters} disabled={!hasDocumentFilterChanges}>
+                      <span class="material-symbols-outlined">check</span>
+                      Bruk filter
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
+        </div>
+
+        <div class="student-filters-selected">
+          {#each appliedFollowUpStudentCheckBoxes.map(getStudentCheckBox) as selectedFollowUpStudentCheckBox}
+            <span class="ds-tag" data-variant="outline" data-color="brand1">{selectedFollowUpStudentCheckBox.value}</span>
+          {/each}
+          {#each appliedFacilitationStudentCheckBoxes.map(getStudentCheckBox) as selectedFacilitationStudentCheckBox}
+            <span class="ds-tag" data-variant="outline" data-color="brand2">{selectedFacilitationStudentCheckBox.value}</span>
+          {/each}
+          {#each appliedTemplateIds.map(getTemplate) as template}
+            <span class="ds-tag" data-variant="outline" data-color="brand3">{template.name}</span>
+          {/each}
+          {#if appliedHasNoDocuments}
+            <span class="ds-tag" data-variant="outline" data-color="neutral">Uten dokumenter</span>
+          {/if}
         </div>
 
         <div>
@@ -488,6 +491,13 @@
         display: flex;
     }
 
+    .student-search-and-filter-container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
     .student-search-container {
         display: flex;
         gap: var(--ds-size-4);
@@ -540,6 +550,7 @@
         display: flex;
         gap: var(--ds-size-1) var(--ds-size-2);
         flex-wrap: wrap;
+        margin-bottom: var(--ds-size-4);
     }
 
     #document-filters-action-container {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -29,7 +29,7 @@
   const followUpStudentCheckBoxes: StudentCheckBox[] = enabledStudentCheckBoxes.filter((checkbox: StudentCheckBox) => checkbox.type === "FOLLOW_UP")
   const facilitationStudentCheckBoxes: StudentCheckBox[] = enabledStudentCheckBoxes.filter((checkbox: StudentCheckBox) => checkbox.type === "FACILITATION")
 
-  // svelte-ignore state_referenced_locally
+  // svelte-ignore state_referenced_locally - det går bra så lenge ikke system admin kødder med document template filter options, da kan de bare refresh sida
   const studentDocumentTemplates: DocumentTemplateFilterOption[] = data.documentTemplateFilterOptions
 
   let selectedFollowUpStudentCheckBoxes: string[] = $state([])

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -35,14 +35,23 @@ const getStudents: ApiNextFunction<GetStudentsResponse, void> = async ({ princip
     throw new HTTPError(400, `Invalid sortDirection value. Valid values are: ${validSortDirectionValues.join(", ")}`)
   }
 
+  const hasNoDocuments = requestEvent.url.searchParams.get("hasNoDocuments") === "true" ? true : undefined
+
   const studentFilter: FrontendOverviewStudentFilter = {
     studentName: requestEvent.url.searchParams.get("studentName") || undefined,
     className: requestEvent.url.searchParams.get("className") || undefined,
     contactTeacherName: requestEvent.url.searchParams.get("contactTeacherName") || undefined,
     studentCheckBoxIds: requestEvent.url.searchParams.getAll("studentCheckBoxIds"),
+    templateIds: requestEvent.url.searchParams.getAll("templateIds"),
+    hasNoDocuments,
     sortBy: (sortBy as FrontendOverviewStudentFilter["sortBy"]) || undefined,
     sortDirection: (sortDirection as FrontendOverviewStudentFilter["sortDirection"]) || undefined,
     top: Number(requestEvent.url.searchParams.get("top")) || undefined
+  }
+
+  // Check that not both hasNoDocuments and templateIds filters are applied at the same time, as this is not supported
+  if (studentFilter.hasNoDocuments && studentFilter.templateIds && studentFilter.templateIds.length > 0) {
+    throw new HTTPError(400, "Cannot apply both hasNoDocuments and templateIds filters at the same time, as this is not supported")
   }
 
   const principalAccess: PrincipalAccess | null = await getPrincipalAccess(principal.id)


### PR DESCRIPTION
### Minor commits:
- feat: refactor chunk size constant and use AND for documentTemplate filters (22dc076)
- feat: sort document template filter options and enhance student filter layout (102963f)
- feat: add validation to prevent combining hasNoDocuments and templateIds filters (6d93bec)
- feat: optimize document access retrieval by chunking student access queries (2f847aa)
- feat: implement filter application logic for document templates (9153425)
- feat: add document template filtering options to layout and integrate into student overview (9820e3c)
- feat: enhance student document access handling with new filtering logic where we check document access as well (8f7d8a4)
- feat: add document filtering options to student overview retrieval (b0f6087)
- feat: add methods to retrieve student IDs with and without documents for templates (4821cf7)

### Patch commits:
- fix: update filter application logic to use applied variables for student checkboxes and templates (78ea739)
- fix: use ObjectId in db-layer for documet.template.id (b7bf7d0)

### Maintenance commits:
- chore: lint:fix (8d981a6)
