### PR TITLE
minor: 1.0.0 - ot-dropouts

### DIFF
--- a/src/lib/utils/period.ts
+++ b/src/lib/utils/period.ts
@@ -1,7 +1,7 @@
 import type { ApplicationInfo, PeriodDetails } from "$lib/types/app-types"
 import type { Period } from "$lib/types/db/shared-types"
 
-const isActive = (period: Period): boolean => {
+export const isActive = (period: Period): boolean => {
   if (!period.start) {
     return false
   }

--- a/src/routes/api/access/[entrauserid]/add/+server.ts
+++ b/src/routes/api/access/[entrauserid]/add/+server.ts
@@ -11,7 +11,7 @@ import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { canGrantAndRemoveAccessForSchool, isSystemAdmin, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
 import type { AccessEntry, PrincipalAccess, PrincipalAccessStudent } from "$lib/types/app-types"
-import type { Access, NewAccess, StudentClassGroup } from "$lib/types/db/shared-types"
+import type { Access, EditorData, NewAccess, StudentClassGroup } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 import { getClassesFromStudents } from "$lib/utils/classes-from-students"
 
@@ -140,15 +140,17 @@ const grantAccess: ApiNextFunction<GrantAccessResponse, GrantAccessBody> = async
     }
   }
 
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
   const accessEntryToAdd: AccessEntry = {
     ...accessEntryInput,
-    granted: {
-      by: {
-        entraUserId: principal.id,
-        fallbackName: principal.displayName
-      },
-      at: new Date()
-    },
+    granted: editorData,
     source: "MANUAL"
   }
 
@@ -163,13 +165,7 @@ const grantAccess: ApiNextFunction<GrantAccessResponse, GrantAccessBody> = async
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "Access",
       resourceId: updatedAccessId,

--- a/src/routes/api/classes/[system_id]/documents/+server.ts
+++ b/src/routes/api/classes/[system_id]/documents/+server.ts
@@ -88,13 +88,7 @@ const addDocument: ApiNextFunction<AddDocumentResponse, AddDocumentBody> = async
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "GroupDocument",
       resourceId: documentId,

--- a/src/routes/api/classes/[system_id]/documents/[document_id]/+server.ts
+++ b/src/routes/api/classes/[system_id]/documents/[document_id]/+server.ts
@@ -198,13 +198,7 @@ const updateDocument: ApiNextFunction<UpdateDocumentResponse, UpdateDocumentBody
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "GroupDocument",
       resourceId: updatedDocumentId,

--- a/src/routes/api/classes/[system_id]/documents/[document_id]/messages/+server.ts
+++ b/src/routes/api/classes/[system_id]/documents/[document_id]/messages/+server.ts
@@ -94,13 +94,7 @@ const addDocumentMessage: ApiNextFunction<AddDocumentMessageResponse, AddDocumen
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "GroupDocumentMessage",
       resourceId: messageId,

--- a/src/routes/api/classes/[system_id]/documents/[document_id]/messages/[message_id]/+server.ts
+++ b/src/routes/api/classes/[system_id]/documents/[document_id]/messages/[message_id]/+server.ts
@@ -108,13 +108,7 @@ const updateDocumentMessage: ApiNextFunction<UpdateDocumentMessageResponse, Upda
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "GroupDocumentMessage",
       resourceId: updatedMessageId,

--- a/src/routes/api/classes/[system_id]/importantstuff/+server.ts
+++ b/src/routes/api/classes/[system_id]/importantstuff/+server.ts
@@ -54,7 +54,7 @@ const updateGroupImportantStuff: ApiNextFunction<PatchGroupImportantStuffRespons
 
   const currentImportantStuff = await dbClient.importantStuff.getGroupImportantStuff(systemId)
 
-  const editor: EditorData = {
+  const editorData: EditorData = {
     by: {
       entraUserId: principal.id,
       fallbackName: principal.displayName
@@ -67,8 +67,8 @@ const updateGroupImportantStuff: ApiNextFunction<PatchGroupImportantStuffRespons
     school: groupImportantStuffData.school,
     importantInfo: groupImportantStuffData.importantInfo,
     lastActivityTimestamp: new Date(),
-    modified: editor,
-    created: currentImportantStuff && currentImportantStuff.length > 0 ? currentImportantStuff[0].created : editor
+    modified: editorData,
+    created: currentImportantStuff && currentImportantStuff.length > 0 ? currentImportantStuff[0].created : editorData
   }
 
   let importantStuffId: string
@@ -86,13 +86,7 @@ const updateGroupImportantStuff: ApiNextFunction<PatchGroupImportantStuffRespons
   if (currentImportantStuff && currentImportantStuff.length > 0) {
     try {
       await dbClient.auditLogs.createAuditEntry({
-        created: {
-          by: {
-            entraUserId: principal.id,
-            fallbackName: principal.displayName
-          },
-          at: new Date()
-        },
+        created: editorData,
         action: "UPDATE",
         resource: "ImportantStuff",
         resourceId: importantStuffId,
@@ -117,13 +111,7 @@ const updateGroupImportantStuff: ApiNextFunction<PatchGroupImportantStuffRespons
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "ImportantStuff",
       resourceId: importantStuffId,

--- a/src/routes/api/programareas/+server.ts
+++ b/src/routes/api/programareas/+server.ts
@@ -63,13 +63,7 @@ const addProgramArea: ApiNextFunction<AddProgramAreaResponse, AddProgramAreaBody
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "ProgramArea",
       resourceId: programAreaId,

--- a/src/routes/api/programareas/[programarea_id]/+server.ts
+++ b/src/routes/api/programareas/[programarea_id]/+server.ts
@@ -8,7 +8,7 @@ import { HTTPError } from "$lib/server/middleware/http-error"
 import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { canAccessSchoolAdministration, canGrantAndRemoveAccessForSchool, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
-import type { NewProgramArea } from "$lib/types/db/shared-types"
+import type { EditorData, NewProgramArea } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 
 type DeleteProgramAreaResponse = ApiRouteMap[`/api/programareas/${NoSlashString}`]["DELETE"]["res"]
@@ -122,17 +122,19 @@ const updateProgramArea: ApiNextFunction<UpdateProgramAreaResponse, UpdateProgra
     throw new HTTPError(403, noAccessMessage("Not allowed to change school of program area"))
   }
 
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
   const updatedProgramArea: NewProgramArea = {
     name: updatedProgramAreaData.name,
     classes: updatedProgramAreaData.classes,
     schoolNumber: programAreaToUpdate.schoolNumber,
-    modified: {
-      by: {
-        entraUserId: principal.id,
-        fallbackName: principal.displayName
-      },
-      at: new Date()
-    },
+    modified: editorData,
     created: programAreaToUpdate.created,
     source: programAreaToUpdate.source
   }
@@ -150,13 +152,7 @@ const updateProgramArea: ApiNextFunction<UpdateProgramAreaResponse, UpdateProgra
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "ProgramArea",
       resourceId: updatedProgramAreaId,

--- a/src/routes/api/schools/+server.ts
+++ b/src/routes/api/schools/+server.ts
@@ -60,13 +60,7 @@ const addSchool: ApiNextFunction<AddSchoolResponse, AddSchoolBody> = async ({ pr
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "School",
       resourceId: schoolId,

--- a/src/routes/api/schools/[schoolnumber]/+server.ts
+++ b/src/routes/api/schools/[schoolnumber]/+server.ts
@@ -7,7 +7,7 @@ import { HTTPError } from "$lib/server/middleware/http-error"
 import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { isSystemAdmin, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
-import type { NewSchool } from "$lib/types/db/shared-types"
+import type { EditorData, NewSchool } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 
 type DeleteSchoolResponse = ApiRouteMap[`/api/schools/${NoSlashString}`]["DELETE"]["res"]
@@ -107,18 +107,20 @@ const updateSchool: ApiNextFunction<UpdateSchoolResponse, UpdateSchoolBody> = as
     throw new HTTPError(400, "You cannot change the school number of an existing school.")
   }
 
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
   const updatedSchool: NewSchool = {
     name: updatedSchoolData.name,
     schoolNumber: schoolToUpdate.schoolNumber, // keep the original school number to prevent changes to it
     source: schoolToUpdate.source, // keep the original source to prevent changes to it
     created: schoolToUpdate.created, // keep the original created info
-    modified: {
-      by: {
-        entraUserId: principal.id,
-        fallbackName: principal.displayName
-      },
-      at: new Date()
-    }
+    modified: editorData
   }
 
   let updatedSchoolId: string
@@ -131,13 +133,7 @@ const updateSchool: ApiNextFunction<UpdateSchoolResponse, UpdateSchoolBody> = as
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "School",
       resourceId: updatedSchoolId,

--- a/src/routes/api/studentcheckboxes/+server.ts
+++ b/src/routes/api/studentcheckboxes/+server.ts
@@ -63,13 +63,7 @@ const addStudentCheckBox: ApiNextFunction<AddStudentCheckBoxResponse, AddStudent
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "StudentCheckBox",
       resourceId: checkBoxId,

--- a/src/routes/api/studentcheckboxes/[checkbox_id]/+server.ts
+++ b/src/routes/api/studentcheckboxes/[checkbox_id]/+server.ts
@@ -7,7 +7,7 @@ import { HTTPError } from "$lib/server/middleware/http-error"
 import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { isSystemAdmin, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
-import type { NewStudentCheckBox } from "$lib/types/db/shared-types"
+import type { EditorData, NewStudentCheckBox } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 import { STUDENT_CHECKBOX_DISPLAY_NAMES } from "$lib/utils/student-checkbox-constants"
 
@@ -101,18 +101,20 @@ const updateStudentCheckBox: ApiNextFunction<UpdateStudentCheckBoxResponse, Upda
     throw new HTTPError(400, `Invalid student check box data: ${validationResult.message}`)
   }
 
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
   const updatedStudentCheckBox: NewStudentCheckBox = {
     type: updatedStudentCheckBoxData.type,
     value: updatedStudentCheckBoxData.value,
     enabled: updatedStudentCheckBoxData.enabled,
     sort: updatedStudentCheckBoxData.sort,
-    modified: {
-      by: {
-        entraUserId: principal.id,
-        fallbackName: principal.displayName
-      },
-      at: new Date()
-    },
+    modified: editorData,
     created: studentCheckBoxToUpdate.created
   }
 
@@ -130,13 +132,7 @@ const updateStudentCheckBox: ApiNextFunction<UpdateStudentCheckBoxResponse, Upda
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "StudentCheckBox",
       resourceId: updatedCheckBoxId,

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -15,7 +15,7 @@ import type { FrontendOverviewStudentFilter, FrontendStudent, PrincipalAccess } 
 import type { AuthenticatedPrincipal } from "$lib/types/authentication"
 import type { ValidationResult } from "$lib/types/data-validation"
 import type { IDbClient } from "$lib/types/db/db-client"
-import type { Access, EditorData, NewAppStudent, Period, StudentEnrollment, UpdateAppStudent } from "$lib/types/db/shared-types"
+import type { Access, EditorData, NewAppStudent, Period, School, StudentEnrollment, UpdateAppStudent } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 import { isActive } from "$lib/utils/period"
 import { generateUUID } from "$lib/utils/uuid"
@@ -103,9 +103,15 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
     }
   }
 
+  const schools: School[] = await dbClient.schools.getSchools()
+  const schoolRecord: School | undefined = schools.find((school) => school.schoolNumber === newManualStudentData.school.schoolNumber)
+  if (!schoolRecord) {
+    throw new HTTPError(400, "Den angitte skolen eksisterer ikke")
+  }
+
   const student: FrontendStudent | null = await dbClient.students.getStudentBySsn(newManualStudentData.ssn)
   if (student) {
-    if (newManualStudentData.school.source === "AUTO") {
+    if (schoolRecord.source === "AUTO") {
       if (student.studentEnrollments.length === 0) {
         throw new HTTPError(500, "Fødselsnummer er allerede i bruk. Eleven har ingen elevforhold. Hvordan skal vi forholde oss til dette da? Ta kontakt med en voksen")
       }

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -225,13 +225,7 @@ const handleNewManualStudent = async (principal: AuthenticatedPrincipal, manualS
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "ManualUser",
       resourceId: studentId,
@@ -335,13 +329,7 @@ const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, ma
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "ManualUser",
       resourceId: studentId,

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -140,6 +140,38 @@ export const POST: RequestHandler = async (requestEvent) => {
   return apiRequestMiddleware<AddManualStudentResponse, AddManualStudentBody>(requestEvent, addManualStudent)
 }
 
+const generateManualStudentEnrollment = (manualStudentData: AddManualStudentBody): StudentEnrollment => {
+  const period: Period = {
+    start: new Date(),
+    end: null
+  }
+
+  return {
+    source: "MANUAL",
+    systemId: generateUUID("MANUAL"),
+    period,
+    school: {
+      schoolNumber: manualStudentData.school.schoolNumber,
+      name: manualStudentData.school.name
+    },
+    mainSchool: true,
+    classMemberships: [
+      {
+        classGroup: {
+          source: "MANUAL",
+          name: `Manuelle elever på ${manualStudentData.school.name}`,
+          systemId: `MANUELLE-ELEVER-${manualStudentData.school.name}`,
+          teachers: []
+        },
+        period,
+        systemId: generateUUID("MANUAL")
+      }
+    ],
+    contactTeacherGroupMemberships: [],
+    teachingGroupMemberships: []
+  }
+}
+
 const handleNewManualStudent = async (principal: AuthenticatedPrincipal, manualStudentData: AddManualStudentBody): Promise<string> => {
   const editorData: EditorData = {
     by: {
@@ -149,14 +181,7 @@ const handleNewManualStudent = async (principal: AuthenticatedPrincipal, manualS
     at: new Date()
   }
 
-  const period: Period = {
-    start: new Date(),
-    end: null
-  }
-
   const manualStudentId: string = generateUUID("MANUAL")
-  const manualEnrollmentId: string = generateUUID("MANUAL")
-  const manualClassMembershipId: string = generateUUID("MANUAL")
 
   const newAppStudent: NewAppStudent = {
     ssn: manualStudentData.ssn,
@@ -167,32 +192,7 @@ const handleNewManualStudent = async (principal: AuthenticatedPrincipal, manualS
     source: "MANUAL",
     created: editorData,
     modified: editorData,
-    studentEnrollments: [
-      {
-        source: "MANUAL",
-        systemId: manualEnrollmentId,
-        period,
-        school: {
-          schoolNumber: manualStudentData.school.schoolNumber,
-          name: manualStudentData.school.name
-        },
-        mainSchool: true,
-        classMemberships: [
-          {
-            classGroup: {
-              source: "MANUAL",
-              name: `Manuelle elever på ${manualStudentData.school.name}`,
-              systemId: `MANUELLE-ELEVER-${manualStudentData.school.name}`,
-              teachers: []
-            },
-            period,
-            systemId: manualClassMembershipId
-          }
-        ],
-        contactTeacherGroupMemberships: [],
-        teachingGroupMemberships: []
-      }
-    ],
+    studentEnrollments: [generateManualStudentEnrollment(manualStudentData)],
     hasBlockedAddress: manualStudentData.hasBlockedAddress ?? false
   }
 
@@ -251,40 +251,12 @@ const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, ma
     at: new Date()
   }
 
-  const period: Period = {
-    start: new Date(),
-    end: null
-  }
-
   const newStudentEnrollments: StudentEnrollment[] = student.studentEnrollments.map((enrollment: StudentEnrollment) => {
     enrollment.mainSchool = false
     return enrollment
   })
 
-  newStudentEnrollments.push({
-    source: "MANUAL",
-    systemId: generateUUID("MANUAL"),
-    period,
-    school: {
-      schoolNumber: manualStudentData.school.schoolNumber,
-      name: manualStudentData.school.name
-    },
-    mainSchool: true,
-    classMemberships: [
-      {
-        classGroup: {
-          source: "MANUAL",
-          name: `Manuelle elever på ${manualStudentData.school.name}`,
-          systemId: `MANUELLE-ELEVER-${manualStudentData.school.name}`,
-          teachers: []
-        },
-        period,
-        systemId: generateUUID("MANUAL")
-      }
-    ],
-    contactTeacherGroupMemberships: [],
-    teachingGroupMemberships: []
-  })
+  newStudentEnrollments.push(generateManualStudentEnrollment(manualStudentData))
 
   const updateAppStudent: UpdateAppStudent = {
     ...student,

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -262,7 +262,12 @@ const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, ma
     end: null
   }
 
-  student.studentEnrollments.push({
+  const newStudentEnrollments: StudentEnrollment[] = student.studentEnrollments.map((enrollment: StudentEnrollment) => {
+    enrollment.mainSchool = false
+    return enrollment
+  })
+
+  newStudentEnrollments.push({
     source: "MANUAL",
     systemId: generateUUID("MANUAL"),
     period,
@@ -290,6 +295,7 @@ const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, ma
   const updateAppStudent: UpdateAppStudent = {
     ...student,
     ssn: manualStudentData.ssn,
+    studentEnrollments: newStudentEnrollments,
     modified: editorData,
     source: "MANUAL"
   }

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -318,7 +318,20 @@ const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, ma
     manualStudentData.school.schoolNumber
   )
 
-  await upsertStudentInCache(student)
+  const frontendStudent: FrontendStudent = {
+    _id: studentId,
+    systemId: updateAppStudent.systemId,
+    studentNumber: updateAppStudent.studentNumber,
+    feideName: updateAppStudent.feideName,
+    name: updateAppStudent.name,
+    source: updateAppStudent.source,
+    studentEnrollments: updateAppStudent.studentEnrollments,
+    created: updateAppStudent.created,
+    modified: updateAppStudent.modified,
+    hasBlockedAddress: updateAppStudent.hasBlockedAddress ?? false
+  }
+
+  await upsertStudentInCache(frontendStudent)
 
   try {
     await dbClient.auditLogs.createAuditEntry({

--- a/src/routes/api/students/+server.ts
+++ b/src/routes/api/students/+server.ts
@@ -12,10 +12,12 @@ import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { canManageManualStudentsOnSchool, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
 import type { FrontendOverviewStudentFilter, FrontendStudent, PrincipalAccess } from "$lib/types/app-types"
+import type { AuthenticatedPrincipal } from "$lib/types/authentication"
 import type { ValidationResult } from "$lib/types/data-validation"
 import type { IDbClient } from "$lib/types/db/db-client"
-import type { Access, EditorData, NewAppStudent, Period, StudentEnrollment } from "$lib/types/db/shared-types"
+import type { Access, EditorData, NewAppStudent, Period, StudentEnrollment, UpdateAppStudent } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
+import { isActive } from "$lib/utils/period"
 import { generateUUID } from "$lib/utils/uuid"
 
 type GetStudentsResponse = ApiRouteMap[`/api/students${NoSlashString}`]["GET"]["res"]
@@ -103,14 +105,42 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
 
   const student: FrontendStudent | null = await dbClient.students.getStudentBySsn(newManualStudentData.ssn)
   if (student) {
-    if (student.studentEnrollments.length === 0) {
-      throw new HTTPError(500, "Fødselsnummer er allerede i bruk. Eleven har ingen elevforhold. Hvordan skal vi forholde oss til dette da? Ta kontakt med en voksen")
+    if (newManualStudentData.school.source === "AUTO") {
+      if (student.studentEnrollments.length === 0) {
+        throw new HTTPError(500, "Fødselsnummer er allerede i bruk. Eleven har ingen elevforhold. Hvordan skal vi forholde oss til dette da? Ta kontakt med en voksen")
+      }
+
+      const schoolName: string = student.studentEnrollments.find((enrollment: StudentEnrollment) => enrollment.mainSchool)?.school.name || student.studentEnrollments[0].school.name
+      throw new HTTPError(400, `Fødselsnummer er allerede i bruk på ${schoolName}. Ta kontakt med en voksen på denne skolen, eller no?`)
     }
 
-    const schoolName: string = student.studentEnrollments.find((enrollment: StudentEnrollment) => enrollment.mainSchool)?.school.name || student.studentEnrollments[0].school.name
-    throw new HTTPError(400, `Fødselsnummer er allerede i bruk på ${schoolName}. Ta kontakt med en voksen på denne skolen, eller no?`)
+    if (student.studentEnrollments.every((enrollment: StudentEnrollment) => !isActive(enrollment.period))) {
+      logger.warn(
+        "SSN is already in use by StudentId {StudentId}. Student has {EnrollmentCount} enrollments and all is inactive. Will change this student to MANUAL and add a manual enrollment",
+        student._id,
+        student.studentEnrollments.length
+      )
+    } else {
+      const schoolName: string = student.studentEnrollments.find((enrollment: StudentEnrollment) => enrollment.mainSchool)?.school.name || student.studentEnrollments[0].school.name
+      throw new HTTPError(
+        400,
+        `Fødselsnummer er allerede i bruk på ${schoolName}. Eleven har ${student.studentEnrollments.length} elevforhold, hvor minst ett er aktivt. Elev kan ikke legges til på denne skolen`
+      )
+    }
   }
 
+  const studentId: string = !student ? await handleNewManualStudent(principal, newManualStudentData) : await handleExistingManualStudent(principal, newManualStudentData, student)
+
+  return {
+    studentId
+  }
+}
+
+export const POST: RequestHandler = async (requestEvent) => {
+  return apiRequestMiddleware<AddManualStudentResponse, AddManualStudentBody>(requestEvent, addManualStudent)
+}
+
+const handleNewManualStudent = async (principal: AuthenticatedPrincipal, manualStudentData: AddManualStudentBody): Promise<string> => {
   const editorData: EditorData = {
     by: {
       entraUserId: principal.id,
@@ -129,11 +159,11 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
   const manualClassMembershipId: string = generateUUID("MANUAL")
 
   const newAppStudent: NewAppStudent = {
-    ssn: newManualStudentData.ssn,
+    ssn: manualStudentData.ssn,
     systemId: manualStudentId,
     studentNumber: manualStudentId,
     feideName: manualStudentId,
-    name: newManualStudentData.name,
+    name: manualStudentData.name,
     source: "MANUAL",
     created: editorData,
     modified: editorData,
@@ -143,16 +173,16 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
         systemId: manualEnrollmentId,
         period,
         school: {
-          schoolNumber: newManualStudentData.school.schoolNumber,
-          name: newManualStudentData.school.name
+          schoolNumber: manualStudentData.school.schoolNumber,
+          name: manualStudentData.school.name
         },
         mainSchool: true,
         classMemberships: [
           {
             classGroup: {
               source: "MANUAL",
-              name: `Manuelle elever på ${newManualStudentData.school.name}`,
-              systemId: `MANUELLE-ELEVER-${newManualStudentData.school.name}`,
+              name: `Manuelle elever på ${manualStudentData.school.name}`,
+              systemId: `MANUELLE-ELEVER-${manualStudentData.school.name}`,
               teachers: []
             },
             period,
@@ -163,8 +193,10 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
         teachingGroupMemberships: []
       }
     ],
-    hasBlockedAddress: newManualStudentData.hasBlockedAddress ?? false
+    hasBlockedAddress: manualStudentData.hasBlockedAddress ?? false
   }
+
+  const dbClient: IDbClient = getDbClient()
 
   let studentId: string
 
@@ -206,18 +238,103 @@ const addManualStudent: ApiNextFunction<AddManualStudentResponse, AddManualStude
       resourceName: newAppStudent.name,
       metaData: {
         parentResource: "School",
-        parentResourceId: newManualStudentData.school.schoolNumber
+        parentResourceId: manualStudentData.school.schoolNumber
       }
     })
   } catch (error) {
     logger.errorException(error, "Failed to create audit entry when creating ManualStudentId {ManualStudentId}", studentId)
   }
 
-  return {
-    studentId
-  }
+  return studentId
 }
 
-export const POST: RequestHandler = async (requestEvent) => {
-  return apiRequestMiddleware<AddManualStudentResponse, AddManualStudentBody>(requestEvent, addManualStudent)
+const handleExistingManualStudent = async (principal: AuthenticatedPrincipal, manualStudentData: AddManualStudentBody, student: FrontendStudent): Promise<string> => {
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
+  const period: Period = {
+    start: new Date(),
+    end: null
+  }
+
+  student.studentEnrollments.push({
+    source: "MANUAL",
+    systemId: generateUUID("MANUAL"),
+    period,
+    school: {
+      schoolNumber: manualStudentData.school.schoolNumber,
+      name: manualStudentData.school.name
+    },
+    mainSchool: true,
+    classMemberships: [
+      {
+        classGroup: {
+          source: "MANUAL",
+          name: `Manuelle elever på ${manualStudentData.school.name}`,
+          systemId: `MANUELLE-ELEVER-${manualStudentData.school.name}`,
+          teachers: []
+        },
+        period,
+        systemId: generateUUID("MANUAL")
+      }
+    ],
+    contactTeacherGroupMemberships: [],
+    teachingGroupMemberships: []
+  })
+
+  const updateAppStudent: UpdateAppStudent = {
+    ...student,
+    ssn: manualStudentData.ssn,
+    modified: editorData,
+    source: "MANUAL"
+  }
+
+  const dbClient: IDbClient = getDbClient()
+
+  let studentId: string
+
+  try {
+    studentId = await dbClient.students.updateManualStudent(updateAppStudent)
+  } catch (error) {
+    throw new HTTPError(500, "Feilet ved oppdatering av manuell bruker", error)
+  }
+
+  logger.info(
+    "Updated manual student with Id {Id} by user {DisplayName} ({PrincipalId}), added a manual enrollment to SchoolNumber {SchoolNumber}",
+    studentId,
+    principal.displayName,
+    principal.id,
+    manualStudentData.school.schoolNumber
+  )
+
+  await upsertStudentInCache(student)
+
+  try {
+    await dbClient.auditLogs.createAuditEntry({
+      created: {
+        by: {
+          entraUserId: principal.id,
+          fallbackName: principal.displayName
+        },
+        at: new Date()
+      },
+      action: "UPDATE",
+      resource: "ManualUser",
+      resourceId: studentId,
+      resourceName: updateAppStudent.name,
+      metaData: {
+        parentResource: "School",
+        parentResourceId: manualStudentData.school.schoolNumber
+      }
+    })
+  } catch (error) {
+    logger.errorException(error, "Failed to create audit entry when updating ManualStudentId {ManualStudentId}", studentId)
+  }
+
+  return studentId
 }

--- a/src/routes/api/students/[student_id]/+server.ts
+++ b/src/routes/api/students/[student_id]/+server.ts
@@ -118,13 +118,7 @@ const updateManualStudent: ApiNextFunction<UpdateManualStudentResponse, UpdateMa
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "ManualUser",
       resourceId: studentId,

--- a/src/routes/api/students/[student_id]/consent/+server.ts
+++ b/src/routes/api/students/[student_id]/consent/+server.ts
@@ -9,7 +9,7 @@ import { HTTPError } from "$lib/server/middleware/http-error"
 import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
 import { canEditStudentDataSharingConsent, noAccessMessage } from "$lib/shared-authorization/authorization"
 import type { ApiRouteMap, NoSlashString } from "$lib/types/api/api-route-map"
-import type { NewStudentDataSharingConsent, StudentDataSharingConsent } from "$lib/types/db/shared-types"
+import type { EditorData, NewStudentDataSharingConsent, StudentDataSharingConsent } from "$lib/types/db/shared-types"
 import type { ApiNextFunction } from "$lib/types/middleware/http-request"
 
 type PatchConsentResponse = ApiRouteMap[`/api/students/${NoSlashString}/consent`]["PATCH"]["res"]
@@ -48,16 +48,18 @@ const updateStudentDataSharingConsent: ApiNextFunction<PatchConsentResponse, Pat
     throw new HTTPError(400, `Invalid request body: ${validationResult.message}`)
   }
 
+  const editorData: EditorData = {
+    by: {
+      entraUserId: principal.id,
+      fallbackName: principal.displayName
+    },
+    at: new Date()
+  }
+
   const upsertConsentData: NewStudentDataSharingConsent = {
     consent: body.consent,
     message: body.message,
-    modified: {
-      by: {
-        entraUserId: principal.id,
-        fallbackName: principal.displayName
-      },
-      at: new Date()
-    }
+    modified: editorData
   }
 
   const dbClient = getDbClient()
@@ -79,13 +81,7 @@ const updateStudentDataSharingConsent: ApiNextFunction<PatchConsentResponse, Pat
   if (currentStudentDataSharingConsent) {
     try {
       await dbClient.auditLogs.createAuditEntry({
-        created: {
-          by: {
-            entraUserId: principal.id,
-            fallbackName: principal.displayName
-          },
-          at: new Date()
-        },
+        created: editorData,
         action: "UPDATE",
         resource: "StudentDataSharingConsent",
         resourceId: upsertedConsentId,
@@ -109,13 +105,7 @@ const updateStudentDataSharingConsent: ApiNextFunction<PatchConsentResponse, Pat
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "StudentDataSharingConsent",
       resourceId: upsertedConsentId,

--- a/src/routes/api/students/[student_id]/documents/+server.ts
+++ b/src/routes/api/students/[student_id]/documents/+server.ts
@@ -103,13 +103,7 @@ const addDocument: ApiNextFunction<AddDocumentResponse, AddDocumentBody> = async
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "StudentDocument",
       resourceId: documentId,
@@ -159,13 +153,7 @@ const addDocument: ApiNextFunction<AddDocumentResponse, AddDocumentBody> = async
 
     try {
       await dbClient.auditLogs.createAuditEntry({
-        created: {
-          by: {
-            entraUserId: principal.id,
-            fallbackName: principal.displayName
-          },
-          at: new Date()
-        },
+        created: editorData,
         action: "CREATE",
         resource: "EmailAlert",
         resourceId: emailAlertId,

--- a/src/routes/api/students/[student_id]/documents/[document_id]/+server.ts
+++ b/src/routes/api/students/[student_id]/documents/[document_id]/+server.ts
@@ -181,13 +181,7 @@ const updateDocument: ApiNextFunction<UpdateDocumentResponse, UpdateDocumentBody
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "StudentDocument",
       resourceId: updatedDocumentId,

--- a/src/routes/api/students/[student_id]/documents/[document_id]/messages/+server.ts
+++ b/src/routes/api/students/[student_id]/documents/[document_id]/messages/+server.ts
@@ -107,13 +107,7 @@ const addDocumentMessage: ApiNextFunction<AddDocumentMessageResponse, AddDocumen
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "StudentDocumentMessage",
       resourceId: messageId,
@@ -163,13 +157,7 @@ const addDocumentMessage: ApiNextFunction<AddDocumentMessageResponse, AddDocumen
 
     try {
       await dbClient.auditLogs.createAuditEntry({
-        created: {
-          by: {
-            entraUserId: principal.id,
-            fallbackName: principal.displayName
-          },
-          at: new Date()
-        },
+        created: editorData,
         action: "CREATE",
         resource: "EmailAlert",
         resourceId: emailAlertId,

--- a/src/routes/api/students/[student_id]/documents/[document_id]/messages/[message_id]/+server.ts
+++ b/src/routes/api/students/[student_id]/documents/[document_id]/messages/[message_id]/+server.ts
@@ -104,13 +104,7 @@ const updateDocumentMessage: ApiNextFunction<UpdateDocumentMessageResponse, Upda
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "StudentDocumentMessage",
       resourceId: updatedMessageId,

--- a/src/routes/api/students/[student_id]/importantstuff/+server.ts
+++ b/src/routes/api/students/[student_id]/importantstuff/+server.ts
@@ -69,7 +69,7 @@ const updateStudentImportantStuff: ApiNextFunction<PatchImportantStuffResponse, 
 
   const currentImportantStuff = await dbClient.importantStuff.getStudentImportantStuff(studentId, [studentImportantStuffData.school.schoolNumber])
 
-  const editor: EditorData = {
+  const editorData: EditorData = {
     by: {
       entraUserId: principal.id,
       fallbackName: principal.displayName
@@ -84,8 +84,8 @@ const updateStudentImportantStuff: ApiNextFunction<PatchImportantStuffResponse, 
     followUp: studentImportantStuffData.followUp,
     facilitation: studentImportantStuffData.facilitation,
     lastActivityTimestamp: new Date(),
-    modified: editor,
-    created: currentImportantStuff && currentImportantStuff.length > 0 ? currentImportantStuff[0].created : editor
+    modified: editorData,
+    created: currentImportantStuff && currentImportantStuff.length > 0 ? currentImportantStuff[0].created : editorData
   }
 
   let importantStuffId: string
@@ -103,13 +103,7 @@ const updateStudentImportantStuff: ApiNextFunction<PatchImportantStuffResponse, 
   if (currentImportantStuff && currentImportantStuff.length > 0) {
     try {
       await dbClient.auditLogs.createAuditEntry({
-        created: {
-          by: {
-            entraUserId: principal.id,
-            fallbackName: principal.displayName
-          },
-          at: new Date()
-        },
+        created: editorData,
         action: "UPDATE",
         resource: "ImportantStuff",
         resourceId: importantStuffId,
@@ -134,13 +128,7 @@ const updateStudentImportantStuff: ApiNextFunction<PatchImportantStuffResponse, 
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "ImportantStuff",
       resourceId: importantStuffId,

--- a/src/routes/api/templates/+server.ts
+++ b/src/routes/api/templates/+server.ts
@@ -54,13 +54,7 @@ const addDocumentContentTemplate: ApiNextFunction<AddDocumentContentTemplateResp
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "CREATE",
       resource: "Template",
       resourceId: templateId,

--- a/src/routes/api/templates/[template_id]/+server.ts
+++ b/src/routes/api/templates/[template_id]/+server.ts
@@ -65,13 +65,7 @@ const updateDocumentContentTemplate: ApiNextFunction<UpdateDocumentContentTempla
 
   try {
     await dbClient.auditLogs.createAuditEntry({
-      created: {
-        by: {
-          entraUserId: principal.id,
-          fallbackName: principal.displayName
-        },
-        at: new Date()
-      },
+      created: editorData,
       action: "UPDATE",
       resource: "Template",
       resourceId: templateId,


### PR DESCRIPTION
### Minor commits:
- feat: Manual schools can add a manual student that already exists in the database as long as the student doesn't have any enrollments or all enrollments are inactive (16d5de1)

### Patch commits:
- fix: Authorization Bypass via Client-Controlled school.source (295b9af)
- fix: The manual enrollment object literal is duplicated verbatim between handleNewManualStudent and handleExistingManualStudent (cc711bd)
- fix: Reuse editorData where possible (c5383ad)
- fix: upsertStudentInCache receives the original student object rather than updateAppStudent, so the cached record has stale source and modified fields (0f3b325)
- fix: New enrollment is unconditionally built with mainSchool: true, leaving existing inactive enrollments also marked mainSchool: true with no normalization step (0abda62)
