### PR TITLE
patch: 1.0.0 - shared-types

### DIFF
--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -1,4 +1,4 @@
-// noinspection JSUnusedGlobalSymbols - Mesteparten er brukt her, noe er brukt i elevoppfolging-server-jobs
+// noinspection JSUnusedGlobalSymbols - Mesteparten er brukt i elevoppfolging, noe er brukt i elevoppfolging-server-jobs
 
 import type { Binary, ObjectId } from "mongodb"
 

--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -1,3 +1,5 @@
+// noinspection JSUnusedGlobalSymbols - Noe er brukt her, mesteparten er brukt i elevoppfolging
+
 import type { Binary, ObjectId } from "mongodb"
 
 /** Undervisningsforhold & Skoleressurs */

--- a/src/lib/types/db/shared-types.ts
+++ b/src/lib/types/db/shared-types.ts
@@ -1,4 +1,4 @@
-// noinspection JSUnusedGlobalSymbols - Noe er brukt her, mesteparten er brukt i elevoppfolging
+// noinspection JSUnusedGlobalSymbols - Mesteparten er brukt her, noe er brukt i elevoppfolging-server-jobs
 
 import type { Binary, ObjectId } from "mongodb"
 


### PR DESCRIPTION
### Maintenance commits:
- chore: No point in checking shared-types for unused, since there will always be unused types here (used in elevoppfolging-server-jobs) (d6e110e)
